### PR TITLE
Update sysfs paths to use /sys/class/fsi-master

### DIFF
--- a/procedures/openfsi/scan.cpp
+++ b/procedures/openfsi/scan.cpp
@@ -29,14 +29,9 @@ using namespace phosphor::logging;
 namespace fs = std::experimental::filesystem;
 namespace fsi_error = sdbusplus::org::open_power::Proc::FSI::Error;
 
-constexpr auto masterScanPath =
-    "/sys/bus/platform/devices/gpio-fsi/fsi0/rescan";
-
-constexpr auto hubScanPath = "/sys/devices/platform/gpio-fsi/fsi0/slave@00:00/"
-                             "00:00:00:0a/fsi1/rescan";
-
-constexpr auto masterCalloutPath =
-    "/sys/devices/platform/gpio-fsi/fsi0/slave@00:00/raw";
+constexpr auto masterScanPath = "/sys/class/fsi-master/fsi0/rescan";
+constexpr auto hubScanPath = "/sys/class/fsi-master/fsi1/rescan";
+constexpr auto masterCalloutPath = "/sys/class/fsi-master/fsi0/slave@00:00/raw";
 
 /**
  * Writes a 1 to the sysfs file passed in to trigger

--- a/targeting.hpp
+++ b/targeting.hpp
@@ -10,13 +10,11 @@ namespace openpower
 namespace targeting
 {
 
-constexpr auto fsiMasterDevPath =
-    "/sys/devices/platform/gpio-fsi/fsi0/slave@00:00/raw";
+constexpr auto fsiMasterDevPath = "/sys/class/fsi-master/fsi0/slave@00:00/raw";
 constexpr auto fsiMasterDevPathOld =
     "/sys/devices/platform/fsi-master/slave@00:00/raw";
 
-constexpr auto fsiSlaveBaseDir =
-    "/sys/devices/platform/gpio-fsi/fsi0/slave@00:00/00:00:00:0a/fsi1/";
+constexpr auto fsiSlaveBaseDir = "/sys/class/fsi-master/fsi1/";
 constexpr auto fsiSlaveBaseDirOld =
     "/sys/devices/platform/fsi-master/slave@00:00/hub@00/";
 


### PR DESCRIPTION
The OpenBMC kernel as of 5.3 supports class based paths for the FSI
devices. This means each master (hardware master, or hub master) appears
under /sys/class/fsi-master, allowing a common path to be used no matter
the hub implementation.

Using this method allows us to the AST2600 hardware master and the
existing GPIO master in the same code base.

Signed-off-by: Joel Stanley <joel@jms.id.au>
Change-Id: Ie4ea1a66bf06c564b8212b10421b0a213b71f217