### PR TITLE
Use sbefifo instead of default kernel as backend for p9

### DIFF
--- a/nmi.service.in
+++ b/nmi.service.in
@@ -4,7 +4,7 @@ Description=Enable Open Power NMI service
 [Service]
 Type=oneshot
 RemainAfterExit=no
-ExecStart=@bindir@/pdbg -a stop
-ExecStart=@bindir@/pdbg -a sreset
+ExecStart=@bindir@/pdbg -b sbefifo -a stop
+ExecStart=@bindir@/pdbg -b sbefifo -a sreset
 SyslogIdentifier=openpower-proc-nmi
 


### PR DESCRIPTION
Since the pdbg upstream got refactored to accommodate p10,  some of the changes from GHE master-p10 did not get picked up.  So, we need to use -b sbefifo as backend to use SBEFIFO backend for secure boot to not block the HW access