### PR TITLE
Fix NMI handling for P9 witherspoon

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,8 +2,7 @@ AM_DEFAULT_SOURCE_EXT = .cpp
 
 systemdsystemunit_DATA = \
   pcie-poweroff@.service \
-  xyz.openbmc_project.Control.Host.NMI.service \
-  nmi.service
+  xyz.openbmc_project.Control.Host.NMI.service 
 
 bin_PROGRAMS = \
 	openpower-proc-control \
@@ -37,7 +36,8 @@ openpower_proc_control_CXXFLAGS = $(PHOSPHOR_LOGGING_CFLAGS) \
 
 openpower_proc_nmi_LDFLAGS = $(PHOSPHOR_LOGGING_LIBS) \
                              $(PHOSPHOR_DBUS_INTERFACES_LIBS) \
-                             $(SDBUSPLUS_LIBS)
+                             $(SDBUSPLUS_LIBS) \
+                             -lpdbg
 
 openpower_proc_nmi_CXXFLAGS = $(PHOSPHOR_LOGGING_CFLAGS) \
                               $(PHOSPHOR_DBUS_INTERFACES_CFLAGS) \

--- a/configure.ac
+++ b/configure.ac
@@ -68,5 +68,4 @@ AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
 AC_CONFIG_FILES([Makefile test/Makefile])
 AC_CONFIG_FILES([pcie-poweroff@.service])
 AC_CONFIG_FILES([xyz.openbmc_project.Control.Host.NMI.service])
-AC_CONFIG_FILES([nmi.service])
 AC_OUTPUT

--- a/nmi_main.cpp
+++ b/nmi_main.cpp
@@ -16,14 +16,22 @@
 
 #include "nmi_interface.hpp"
 
+#include <libpdbg.h>
+
 #include <sdbusplus/bus.hpp>
 
-int main(int argc, char* argv[])
+int main(int, char*[])
 {
 
     constexpr auto BUSPATH_NMI = "/xyz/openbmc_project/control/host0/nmi";
     constexpr auto BUSNAME_NMI = "xyz.openbmc_project.Control.Host.NMI";
     auto bus = sdbusplus::bus::new_default();
+
+    //Set the back end as SBEFIFO by default
+    pdbg_set_backend(PDBG_BACKEND_SBEFIFO, NULL);
+
+    //Use the default device  tree
+    pdbg_targets_init(NULL);
 
     // Add sdbusplus ObjectManager
     sdbusplus::server::manager::manager objManager(bus, BUSPATH_NMI);


### PR DESCRIPTION
Change-Id: I86692cd06b288933023baffc0e27ed0f24723a0e
Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>

Fix NMI handling for P9 witherspoon
   - Use SBEFIFO as backend
   - Processor and PIB targets are probed before triggering stop all and sreset all to initiated NMI
   - Use thread_stop_all() and thread_sreset_all() library calls instead of doing using pdbg CLI