### PR TITLE
remove wants on synch targets in stop-instructions

### DIFF
--- a/service_files/op-stop-instructions@.service.in
+++ b/service_files/op-stop-instructions@.service.in
@@ -1,8 +1,6 @@
 [Unit]
 Description=Stop instructions for host%i
-Wants=obmc-host-stop-pre@%i.target
 After=obmc-host-stop-pre@%i.target
-Wants=obmc-host-stopping@%i.target
 Before=obmc-host-stopping@%i.target
 After=op-occ-disable@%i.service
 After=openpower-update-bios-attr-table.service


### PR DESCRIPTION
openbmc/phosphor-state-manager#21 highlights an architecture issue with
OpenBMC's use of synchronization targets. When a service, such as
op-stop-instructions@.service, runs both in a standard power off
target, as well as in other paths (like the host quiesce path), there
is an issue.

The service starts the synchronization targets in the quiesce path and
this causes them to already be running on the power off, resulting in
the synchronization targets not actually coordinating the power off.

The direction this commit takes OpenBMC is that if a service needs to
run outside of the standard power on or off path, then they can not
have a Wants or Requires clause in the service file.

The following commit was done a while back to address this issue:
  https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/40026

That is that we ensure the primary power on and off targets start the
synchronization targets so services requiring them can just use a
Before or After clause.

The piece that was never done was to go and fix the services which fell
into this bucket.

Tested:
- Did multiple boots, reboots, and host crash tests and saw no issues

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: Ida68d83e2c2c18484eb4f28bc55c91fa5ff94930