### PR TITLE
1020: Make ATTN service stop a non-fatal event & Stop ATTN service before instruction stop

### DIFF
--- a/service_files/op-continue-mpreboot@.service.in
+++ b/service_files/op-continue-mpreboot@.service.in
@@ -13,6 +13,7 @@ ConditionPathExists=/run/openbmc/mpreboot@%i
 
 [Service]
 @ENABLE_PHAL_TRUE@Environment="PDBG_DTB=@CEC_DEVTREE_RW_PATH@"
+ExecStart=/bin/systemctl restart attn_handler.service
 ExecStart=/bin/rm -f /run/openbmc/mpreboot@%i
 ExecStart=/usr/bin/openpower-proc-control startHostMpReboot
 Type=oneshot

--- a/service_files/op-stop-instructions@.service.in
+++ b/service_files/op-stop-instructions@.service.in
@@ -12,6 +12,7 @@ ConditionPathExists=!/run/openbmc/mpreboot@%i
 RemainAfterExit=yes
 Type=oneshot
 TimeoutStartSec=20
+ExecStart=/bin/systemctl stop attn_handler.service
 ExecStart=/usr/bin/openpower-proc-control threadStopAll
 
 [Install]

--- a/service_files/op-stop-instructions@.service.in
+++ b/service_files/op-stop-instructions@.service.in
@@ -12,7 +12,7 @@ ConditionPathExists=!/run/openbmc/mpreboot@%i
 RemainAfterExit=yes
 Type=oneshot
 TimeoutStartSec=20
-ExecStart=/bin/systemctl stop attn_handler.service
+ExecStart=/bin/sh -c 'systemctl stop attn_handler.service || true'
 ExecStart=/usr/bin/openpower-proc-control threadStopAll
 
 [Install]


### PR DESCRIPTION
#### Make ATTN service stop a non-fatal event
```
Return true always for request to stop the ATTN service. This is
needed to pass CI in cases where the ATTN service is not installed.

Tested: With change in place when op-stop-instructions service is
started verify that journal does not indicate a failure in
op-stop-instructions service specifically in current iteration of
hardware CI.

Signed-off-by: Ben Tyner <ben.tyner@ibm.com>
Change-Id: Id1852082c768dd742afb85098a2120bda1acb41b
```
#### Stop ATTN service before instruction stop
```
Ensuring that ATTN service is stopped after PHYP has completed the power
off process. PHYP must be done before starting instruction stop. So that
is a good target to use.

ATTN service will not be stopped in the MPIPL case since the instruction
stop service is not used. We need to explicitly restart ATTN service in
MPIPL continue so that attention interrupts with no active attention
sources get cleared.

Tested: Verified on graceful shutdown that attention handler service was
stopped after soft-off app had finished (perform graceful shutdown).
Verified that following an MPIPL attention handler would service
attentions (inject error following MPIPL completion).

Change-Id: I52fb75a0bbfa48c714850aa2d3ed9229179cceea
Signed-off-by: Zane Shelley <zshelle@us.ibm.com>
Signed-off-by: Ben Tyner <ben.tyner@ibm.com>
```