### PR TITLE
phal: Create PEL for empty guard file

### DIFF
--- a/extensions/phal/phal_error.cpp
+++ b/extensions/phal/phal_error.cpp
@@ -356,6 +356,9 @@ void processIplErrorCallback(const ipl_error_info& errInfo)
             // Handle non functional boot processor error.
             processNonFunctionalBootProc();
             break;
+        case IPL_ERR_GUARD_PARTITION_ACCESS:
+            processGuardPartitionAccessError();
+            break;
         default:
             createPEL("org.open_power.PHAL.Error.Boot");
             // reset trace log and exit
@@ -851,6 +854,21 @@ void processSbeBootError()
             // TODO revist error handling.
         }
     }
+}
+
+void processGuardPartitionAccessError()
+{
+    // Adding collected phal logs into PEL additional data
+    FFDCData pelAdditionalData;
+
+    for_each(
+        traceLog.begin(), traceLog.end(),
+        [&pelAdditionalData](std::pair<std::string, std::string>& ele) -> void {
+            pelAdditionalData.emplace_back(ele.first, ele.second);
+        });
+
+    openpower::pel::createPEL("org.open_power.PHAL.Error.GuardPartitionAccess",
+                              pelAdditionalData);
 }
 
 void reset()

--- a/extensions/phal/phal_error.hpp
+++ b/extensions/phal/phal_error.hpp
@@ -57,6 +57,14 @@ void processBootError(bool status);
 void processSbeBootError();
 
 /**
+ * @brief Process Guard Partition Access Error
+ *
+ * This function is used process access error related to guard partition during
+ * boot. It collects the traces and create a PEL
+ */
+void processGuardPartitionAccessError();
+
+/**
  * @brief Reset trace log list
  */
 void reset();


### PR DESCRIPTION
Currently at the time of IPLing if the guard file is not present or found empty, the IPLing terminates with an exception.

Added the new PEL "org.open_power.PHAL.Error.GuardPartitionAccess" to address the above issue and continue to boot

Adding the IPL_ERR_GUARD_PARTITION_ACCESS enables us to generate the PEL and "User Data 1" provides more information regarding the PEL

Tested:
Point to dummy file instead of actual guard file
Using the above error in the ipl callback, able to generate the below PEL {
    "0x50000E0C": {
        "SRC":                  "BD8D300B",
        "Message":              "Guard partition access failure",
        "PLID":                 "0x50000E0C",
        "CreatorID":            "BMC",
        "Subsystem":            "BMC Firmware",
        "Commit Time":          "10/06/2022 12:33:57",
        "Sev":                  "Predictive Error",
        "CompID":               "0x3000"
    }
}
...
    },
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this type as a
unit",
            "Procedure":        "BMC0001"
        }]
    }
},
...
    "LOG013 2022-10-06 12:33:57": "Guard file
/var/lib/phosphor-software-manager/hostfw/running/NOFILE does not exist",
    "_PID": "4393"
}

Signed-off-by: deepakala karthikeyan <deepakala.karthikeyan@ibm.com>
Change-Id: I9b48915b46ee112733b36c7e466ad93489e2f585