### PR TITLE
1050: PHAL:Fix missing clock diagnostic data during ipl

### DIFF
--- a/extensions/phal/clock_logger.cpp
+++ b/extensions/phal/clock_logger.cpp
@@ -78,18 +78,6 @@ void Manager::timerExpired()
 
 void Manager::createClockDataLog()
 {
-    // check chassis power state.
-    auto powerState = openpower::util::getChassisPowerState();
-
-    if (powerState != "xyz.openbmc_project.State.Chassis.PowerState.On")
-    {
-        warning("The chassis power state({POWERSTATE}) is not ON, Skipping "
-                "clock data "
-                "logging",
-                "POWERSTATE", powerState);
-        return;
-    }
-
     // Data logger storage
     FFDCData clockDataLog;
 


### PR DESCRIPTION
#### PHAL:Fix missing clock diagnostic data during ipl
```
During the IPL process, the Chassis Power State D-Bus property is
updated once all services and targets within the Chassis Power On target
have been completed. During this specific timeframe, when the
"op-clock-data-logger@.service.in" initiates, it may fail to capture
clock data due to a failed check. This situation occurs because, even
though the chassis power is turned on, the D-Bus property does not
provide the precise status, resulting in a missed opportunity to record
informational clock data.

The "op-clock-data-logger@.service.in" service is already configured to
start after the "obmc-host-started@%i.target" and is set to conflict
with the "obmc-host-stop@%i.target." This design ensures that whenever
this method is invoked, the chassis power will always be in the ON
state. Therefore, there is no need to redundantly check the chassis
power state for being ON. Consequently, the redundant conditional
statement has been removed.

Tested and found the clock informational diagnostic data added after
every ipl.

Change-Id: I56e62467be14c6f203d163d86aa6a5fd748d0d85
Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>
```