### PR TITLE
Create redundant BMC CFAM-S app framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # openpower-proc-control
 
-Contains procedures that interact with the OpenPower nest chipset.
+Contains:
+
+1. Procedures that interact with the OpenPower nest chipset.
+2. An application that
+   [interfaces with CFAM-S chips](rbmc-cfam-daemon/README.md) on certain
+   systems.
 
 ## To Build
 
 To build this package, do the following steps:
 
-    1. meson builddir
-    2. ninja -C builddir
+    1. meson setup builddir
+    2. meson compile -C builddir
 
 To build with phal feature:
 
-    1. meson builddir -Dphal=enabled -Dopenfsi=enabled
-    2. ninja -C builddir
+    1. meson setup builddir -Dphal=enabled -Dopenfsi=enabled
+    2. meson compile -C builddir
 
 To clean the repository run `ninja -C builddir/ clean`.

--- a/meson.build
+++ b/meson.build
@@ -288,3 +288,7 @@ if not get_option('tests').disabled()
         )
     )
 endif
+
+if get_option('rbmc-cfam-daemon').allowed()
+  subdir('rbmc-cfam-daemon')
+endif

--- a/meson.options
+++ b/meson.options
@@ -32,3 +32,6 @@ option('op_dump_obj_path', type: 'string',
         value: '/org/openpower/dump',
         description : 'Object path requesting OpenPOWER dumps')
 
+option('rbmc-cfam-daemon', type: 'feature',
+       value: 'enabled',
+       description: 'Enable the RBMC CFAM daemon')

--- a/rbmc-cfam-daemon/README.md
+++ b/rbmc-cfam-daemon/README.md
@@ -1,0 +1,18 @@
+# RBMC CFAM Daemon
+
+Each BMC in IBM's redundant BMC system has an FSI connection to its own CFAM-S
+(CFAM-S = a standalone CFAM chip) as well as the sibling BMC's CFAM-S. The four
+scratchpad registers in the Gemini mailbox block in these CFAMs will be used for
+communication between the BMCs.
+
+The local BMC will write the registers in its own CFAM. The sibling BMC would
+then read these to obtain the information.
+
+On startup the rbmc-cfamd application on the local BMC will collect the
+information the sibling needs and write it into its own CFAM. It will watch
+D-Bus in case it needs to update a field on a change.
+
+It will read the sibling's CFAM every 2 seconds. A D-Bus interface will be
+created to make these values available to other applications.
+
+The `rbmc-cfam-daemon` meson option will enable building this code.

--- a/rbmc-cfam-daemon/meson.build
+++ b/rbmc-cfam-daemon/meson.build
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+subdir('src')

--- a/rbmc-cfam-daemon/src/application.cpp
+++ b/rbmc-cfam-daemon/src/application.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "application.hpp"
+
+sdbusplus::async::task<> Application::run()
+{
+    using namespace std::chrono_literals;
+
+    while (!ctx.stop_requested())
+    {
+        // TODO: Read CFAMs
+        co_await sdbusplus::async::sleep_for(ctx, 2s);
+    }
+
+    co_return;
+}

--- a/rbmc-cfam-daemon/src/application.hpp
+++ b/rbmc-cfam-daemon/src/application.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <sdbusplus/async.hpp>
+
+class Application
+{
+  public:
+    Application() = delete;
+    ~Application() = default;
+    Application(const Application&) = delete;
+    Application& operator=(const Application&) = delete;
+    Application(Application&&) = delete;
+    Application& operator=(Application&&) = delete;
+
+    /**
+     * @brief Constructor
+     * @param ctx - The async context object
+     */
+    explicit Application(sdbusplus::async::context& ctx) : ctx(ctx)
+    {
+        ctx.spawn(run());
+    }
+
+  private:
+    /**
+     * @brief Starts the CFAM-S read loop.
+     */
+    sdbusplus::async::task<> run();
+
+    /**
+     * @brief The async context object
+     */
+    sdbusplus::async::context& ctx;
+};

--- a/rbmc-cfam-daemon/src/cfam_main.cpp
+++ b/rbmc-cfam-daemon/src/cfam_main.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "application.hpp"
+
+int main()
+{
+    sdbusplus::async::context ctx;
+
+    Application app{ctx};
+
+    ctx.run();
+
+    return 0;
+}

--- a/rbmc-cfam-daemon/src/meson.build
+++ b/rbmc-cfam-daemon/src/meson.build
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+installdir = join_paths(get_option('libexecdir'), 'openpower-proc-control')
+
+cfam_deps = [
+      sdbusplus_dep,
+      pdi_dep,
+      phosphor_logging_dep,
+]
+
+sources = [
+    'application.cpp',
+    'cfam_main.cpp',
+]
+
+executable('rbmc-cfamd',
+    sources,
+    dependencies: [
+      cfam_deps
+    ],
+    install: true,
+    install_dir: installdir,
+)


### PR DESCRIPTION
Some background:
Each BMC in IBM's redundant BMC system has an FSI connection to its own CFAM-S (CFAM-S = a standalone CFAM) as well as the sibling BMC's CFAM-S. The four scratchpad registers in the Gemini mailbox block in these CFAMs will be used for communication between the BMCs.

The local BMC will write the registers in its own CFAM.  The sibling BMC would then read these to obtain the information.

On startup the local BMC will collect the information the sibling needs and write it into its CFAM.  It may also watch D-Bus in case it needs to update a field on a change.

The sibling's CFAM will be read every N seconds, where N = 2 in this commit to start with. A D-Bus interface will be created to make these values available to other applications.

This commit creates a new application rbmc-cfamd to do this.  It is enabled with a new 'rbmc-cfam-daemon' meson option.  Initially it will just go into a 2 second loop, not doing anything.

The commit doesn't include a service file because it will be named after its D-Bus service name, which in turn is named after it's D-Bus interface, and that isn't in yet.

Change-Id: I1fcd62cc550f0f78bd4be1852417ad7124ef664c