### PR TITLE
CFAM: Put sibling values on D-Bus

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -261,6 +261,12 @@ unit_files = [
     'service_files/op-enter-mpreboot@.service',
 ] + extra_unit_files
 
+if get_option('rbmc-cfam-daemon').allowed()
+  unit_files += [
+      'service_files/xyz.openbmc_project.State.BMC.Redundancy.Sibling.service'
+  ]
+endif
+
 systemd_system_unit_dir = dependency('systemd').get_variable(
     'systemdsystemunitdir',
     pkgconfig_define: ['prefix', get_option('prefix')])

--- a/rbmc-cfam-daemon/src/application.cpp
+++ b/rbmc-cfam-daemon/src/application.cpp
@@ -4,12 +4,26 @@
 sdbusplus::async::task<> Application::run()
 {
     using namespace std::chrono_literals;
+    CFAMAccess link1{1, *sysfs.get()};
 
     co_await localBMC.start();
 
     while (!ctx.stop_requested())
     {
-        // TODO: Read sibling CFAM
+        // Eventually what's off of link 1 may not be a BMC and we'll need
+        // a way to know that.  For now, assume it's the sibling BMC's CFAM
+        // if it's there.
+        if (!siblingBMC && link1.exists())
+        {
+            siblingBMC = std::make_unique<SiblingBMC>(ctx, 1, *sysfs.get());
+        }
+
+        if (siblingBMC)
+        {
+            siblingBMC->read();
+            localBMC.setSiblingCommsOK(siblingBMC->ok());
+        }
+
         co_await sdbusplus::async::sleep_for(ctx, 2s);
     }
 

--- a/rbmc-cfam-daemon/src/application.hpp
+++ b/rbmc-cfam-daemon/src/application.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "local_bmc.hpp"
+#include "sibling_bmc.hpp"
 #include "sysfs.hpp"
 
 #include <sdbusplus/async.hpp>
@@ -48,4 +49,11 @@ class Application
      * @brief Handles logic for the local BMC.
      */
     LocalBMC localBMC;
+
+    /**
+     * @brief Handles logic for the sibling BMC.
+     *
+     * Only created if sibling is present.
+     */
+    std::unique_ptr<SiblingBMC> siblingBMC;
 };

--- a/rbmc-cfam-daemon/src/cfam_main.cpp
+++ b/rbmc-cfam-daemon/src/cfam_main.cpp
@@ -6,7 +6,15 @@ int main()
     sdbusplus::async::context ctx;
     std::unique_ptr<SysFS> sysfs = std::make_unique<SysFSImpl>();
 
+    sdbusplus::server::manager_t objMgr{
+        ctx, SiblingInterface::namespace_path::value};
+
     Application app{ctx, std::move(sysfs)};
+
+    ctx.spawn([](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
+        ctx.request_name(SiblingInterface::interface);
+        co_return;
+    }(ctx));
 
     ctx.run();
 

--- a/rbmc-cfam-daemon/src/local_bmc.cpp
+++ b/rbmc-cfam-daemon/src/local_bmc.cpp
@@ -72,6 +72,7 @@ void LocalBMC::writeBMCPosition()
 void LocalBMC::writeSiblingCommsNotOK()
 {
     cfam.writeSiblingCommsOK(false);
+    siblingOK = false;
 }
 
 void LocalBMC::writeProvisioned()
@@ -134,4 +135,12 @@ sdbusplus::async::task<> LocalBMC::writeBMCState()
     }
 
     co_return;
+}
+void LocalBMC::setSiblingCommsOK(bool ok)
+{
+    if (ok != siblingOK)
+    {
+        cfam.writeSiblingCommsOK(ok);
+        siblingOK = ok;
+    }
 }

--- a/rbmc-cfam-daemon/src/local_bmc.hpp
+++ b/rbmc-cfam-daemon/src/local_bmc.hpp
@@ -42,6 +42,15 @@ class LocalBMC
      */
     sdbusplus::async::task<> start();
 
+    /**
+     * @brief Sets the 'sibling communications OK' bit in the local CFAM.
+     *
+     * This represents if this local BMC could read the sibling's CFAM or not.
+     *
+     * @param[in] ok - If these communications are good or not.
+     */
+    void setSiblingCommsOK(bool ok);
+
   private:
     using Role =
         sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
@@ -133,4 +142,12 @@ class LocalBMC
      * @brief Object to read data from the system.
      */
     std::unique_ptr<Services> services;
+
+    /**
+     * @brief The current sibling communications OK value.
+     *
+     * Used so that the CFAM doesn't have to be written
+     * on every poll.
+     */
+    bool siblingOK{false};
 };

--- a/rbmc-cfam-daemon/src/meson.build
+++ b/rbmc-cfam-daemon/src/meson.build
@@ -16,6 +16,7 @@ sources = [
     'local_bmc.cpp',
     'local_cfam.cpp',
     'sibling_cfam.cpp',
+    'sibling_bmc.cpp',
     'services.cpp',
     'sysfs.cpp',
 ]

--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "sibling_bmc.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <format>
+
+void SiblingBMC::read()
+{
+    bool createdIface = false;
+
+    if (!cfam.isReady())
+    {
+        if (ready)
+        {
+            lg2::info("Sibling CFAM device changed to not ready");
+            ready = false;
+        }
+
+        if (siblingInterface)
+        {
+            lg2::info(
+                "Removing sibling interface from D-Bus due to CFAM not ready");
+            siblingInterface.reset();
+        }
+        return;
+    }
+
+    if (!ready)
+    {
+        lg2::info("Sibling CFAM device changed to ready");
+        ready = true;
+    }
+
+    cfam.readAll();
+
+    if (cfam.hasError())
+    {
+        if (siblingInterface)
+        {
+            lg2::info("Removing sibling API from D-Bus due to CFAM error");
+            siblingInterface.reset();
+        }
+        return;
+    }
+
+    if (!siblingInterface)
+    {
+        lg2::info("Creating Sibling D-Bus interface");
+
+        auto objectPath =
+            sdbusplus::message::object_path{
+                SiblingInterface::namespace_path::value} /
+            SiblingInterface::namespace_path::bmc;
+
+        siblingInterface = std::make_unique<SiblingInterface>(
+            ctx.get_bus(), objectPath.str.c_str(),
+            SiblingInterface::action::defer_emit);
+
+        createdIface = true;
+    }
+
+    siblingInterface->communicationOK(cfam.getSiblingCommsOK(), createdIface);
+    siblingInterface->bmcPosition(cfam.getBMCPosition(), createdIface);
+    siblingInterface->provisioned(cfam.getProvisioned(), createdIface);
+    siblingInterface->role(cfam.getRole(), createdIface);
+    siblingInterface->redundancyEnabled(cfam.getRedundancyEnabled(),
+                                        createdIface);
+    siblingInterface->failoversPaused(cfam.getFailoversPaused(), createdIface);
+    siblingInterface->bmcState(cfam.getBMCState(), createdIface);
+
+    auto version = std::format("{:X}", cfam.getFWVersion());
+    siblingInterface->fwVersion(version, createdIface);
+
+    // Must detect a heartbeat change to consider it active, so it won't
+    // be active until at least the second time though.
+    auto heartbeat = cfam.getHeartbeat();
+    auto alive = lastHeartbeat.has_value() &&
+                 (heartbeat != lastHeartbeat.value());
+    siblingInterface->heartbeat(alive, createdIface);
+    lastHeartbeat = heartbeat;
+
+    if (createdIface)
+    {
+        siblingInterface->emit_object_added();
+    }
+}

--- a/rbmc-cfam-daemon/src/sibling_bmc.hpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.hpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include "sibling_cfam.hpp"
+
+#include <sdbusplus/async.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/Sibling/server.hpp>
+
+using SiblingIntf =
+    sdbusplus::xyz::openbmc_project::State::BMC::Redundancy::server::Sibling;
+using SiblingInterface = sdbusplus::server::object_t<SiblingIntf>;
+
+/**
+ * @class SiblingBMC
+ *
+ * Represents the sibling BMC.  Responsible for holding the Sibling D-Bus
+ * interface, which is populated from fields in the sibling's CFAM.
+ * The interface's properties are updated after calls to read().
+ */
+class SiblingBMC
+{
+  public:
+    using Role =
+        sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
+    using BMCState =
+        sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+
+    SiblingBMC() = delete;
+    ~SiblingBMC() = default;
+    SiblingBMC(const SiblingBMC&) = delete;
+    SiblingBMC& operator=(const SiblingBMC&) = delete;
+    SiblingBMC(SiblingBMC&&) = delete;
+    SiblingBMC& operator=(SiblingBMC&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] ctx - The async context object
+     * @param[in] link - The FSI link for the CFAM
+     * @param[in] sysfs - The sysfs object
+     */
+    SiblingBMC(sdbusplus::async::context& ctx, size_t link, SysFS& sysfs) :
+        ctx(ctx), cfam(link, sysfs)
+    {}
+
+    /**
+     * @brief Read's the sibling's CFAM scratchpad registers and puts the
+     *        values on D-Bus.
+     *
+     * More specifically, it will:
+     *
+     * 1) Read all CFAM registers that have fields defined
+     * 2) Create and/or update the Sibling D-Bus interface with these values.
+     * 3) If there are errors, remove the interface from D-Bus so nobody
+     *    can read stale values.
+     */
+    void read();
+
+    /**
+     * @brief Says if it could successfully read the CFAM.
+     *
+     * @return bool - if the CFAM could be read without an error.
+     */
+    bool ok() const
+    {
+        return cfam.isReady() && !cfam.hasError();
+    }
+
+  private:
+    /**
+     * @brief The context object
+     */
+    sdbusplus::async::context& ctx;
+
+    /**
+     * @brief The Sibling D-Bus interface
+     */
+    std::unique_ptr<SiblingInterface> siblingInterface;
+
+    /**
+     * @brief The last heartbeat value read from the CFAM.
+     */
+    std::optional<uint32_t> lastHeartbeat;
+
+    /**
+     * @brief If the sibling CFAM is ready, meaning its sysfs
+     *        files are there.
+     *
+     *        Used as a flag to bound tracing.
+     */
+    bool ready = false;
+
+    /**
+     * @brief The SiblingCFAM object to handle the reads.
+     */
+    SiblingCFAM cfam;
+};

--- a/service_files/xyz.openbmc_project.State.BMC.Redundancy.Sibling.service.in
+++ b/service_files/xyz.openbmc_project.State.BMC.Redundancy.Sibling.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=Redundant BMC Sibling service
+Wants=xyz.openbmc_project.State.BMC.service
+After=xyz.openbmc_project.State.BMC.service
+
+[Service]
+ExecStart=/usr/libexec/openpower-proc-control/rbmc-cfamd
+Restart=always
+Type=dbus
+BusName=xyz.openbmc_project.State.BMC.Redundancy.Sibling
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit creates a SiblingBMC class to poll the sibling CFAMs and put the values on D-Bus.  The D-Bus details are:

service: xyz.openbmc_project.State.BMC.Redundancy.Sibling
interface: xyz.openbmc_project.State.BMC.Redundancy.Sibling
object path: /xyz/openbmc_projec/state/bmc1

A service file to run the application named after the D-Bus service is now included.

For now, the SiblingBMC class is created if any CFAM off of link 1 is present.  In the future when more is known about the system, there may need to be changes to identify that CFAM as one on a BMC card, and possibly even look at other links for the BMC's CFAM.

To ensure that D-Bus clients are getting valid values, the interface won't be created until the CFAM is successfully read, and will be removed if the CFAM cannot be accessed.

Tested:
```
$ busctl introspect -l xyz.openbmc_project.State.BMC.Redundancy.Sibling  /xyz/openbmc_project/state/bmc1
NAME                                             TYPE      SIGNATURE RESULT/VALUE                                            FLAGS
xyz.openbmc_project.State.BMC.Redundancy.Sibling interface -         -                                                       -
.BMCPosition                                     property  u         1                                                       emits-change
.BMCState                                        property  s         "xyz.openbmc_project.State.BMC.BMCState.Quiesced"       emits-change
.CommsOK                                         property  b         true                                                    emits-change
.FWVersion                                       property  s         "DD59CE3D"                                              emits-change
.FailoversPaused                                 property  b         false                                                   emits-change
.Heartbeat                                       property  b         true                                                    emits-change
.Provisioned                                     property  b         false                                                   emits-change
.RedundancyEnabled                               property  b         false                                                   emits-change
.Role                                            property  s         "xyz.openbmc_project.State.BMC.Redundancy.Role.Passive" emits-change
```

and fields accurately reflect the values in the CFAM.

Change-Id: I4cd171b737e2f63353fd5317b7ff694cfa4dd37e