### PR TITLE
CFAM: Use SHA512 for FW version hash

### DIFF
--- a/rbmc-cfam-daemon/src/meson.build
+++ b/rbmc-cfam-daemon/src/meson.build
@@ -2,10 +2,13 @@
 
 installdir = join_paths(get_option('libexecdir'), 'openpower-proc-control')
 
+ssl_dep = dependency('openssl')
+
 cfam_deps = [
       sdbusplus_dep,
       pdi_dep,
       phosphor_logging_dep,
+      ssl_dep,
 ]
 
 sources = [


### PR DESCRIPTION
Unlike std::hash, this one is supposed to be more consistent and unique.

This was just implemented in phosphor-rbmc-state-manager and they both have to be done the same so the BMCs can have their versions compared.

Tested:
Hashes still work and are different across different drivers.
```
$ cfamstool -d
Local BMC CFAM-S scratchpad fields
...
FW Version                 0x2f82fb1e

Sibling BMC CFAM-S scratchpad fields
...
FW Version                 0x2f82fb1e
```

Change-Id: Ibb64f75c2620b0e8ca4ff91a316a0eef0b81074f