### PR TITLE
CFAM: FailoversPaused D-Bus support

### DIFF
--- a/rbmc-cfam-daemon/src/local_bmc.hpp
+++ b/rbmc-cfam-daemon/src/local_bmc.hpp
@@ -129,6 +129,16 @@ class LocalBMC
     void redEnabledChanged(bool enabled);
 
     /**
+     * @brief Callback function for when the failovers paused
+     * D-Bus property changes.
+     *
+     * Writes the new value into the CFAM.
+     *
+     * @param[in] paused - Value to write
+     */
+    void failoversPausedChanged(bool paused);
+
+    /**
      * @brief The context object
      */
     sdbusplus::async::context& ctx;

--- a/rbmc-cfam-daemon/src/services.hpp
+++ b/rbmc-cfam-daemon/src/services.hpp
@@ -23,6 +23,7 @@ class Services
     using BMCStateCallback = std::function<void(BMCState)>;
     using RoleCallback = std::function<void(Role)>;
     using RedEnabledCallback = std::function<void(bool)>;
+    using FailoversPausedCallback = std::function<void(bool)>;
 
     Services() = delete;
     ~Services() = default;
@@ -41,10 +42,13 @@ class Services
      * @param[in] roleCallback - Function to run when the role changes
      * @param[in] redEnabledCallback - Function to run when the
      *                                 redundancyEnabled prop changes
+     * @param[in] failoversPausedCallback - Function to run when this prop
+     *                                      changes
      */
     Services(sdbusplus::async::context& ctx, BMCStateCallback&& stateCallback,
              RoleCallback&& roleCallback,
-             RedEnabledCallback&& redEnabledCallback);
+             RedEnabledCallback&& redEnabledCallback,
+             FailoversPausedCallback&& failoversPausedCallback);
 
     /**
      * @brief Reads the CurrentBMCState property
@@ -58,7 +62,7 @@ class Services
      *
      * @return - A tuple of the role and redundancyEnabled property
      */
-    sdbusplus::async::task<std::tuple<Services::Role, bool>>
+    sdbusplus::async::task<std::tuple<Services::Role, bool, bool>>
         getRedundancyProps();
 
     /**
@@ -129,4 +133,9 @@ class Services
      * @brief The callback function for RedundancyEnabled
      */
     RedEnabledCallback redEnabledCallback;
+
+    /**
+     * @brief The callback function for FailoversPaused
+     */
+    FailoversPausedCallback failoversPausedCallback;
 };


### PR DESCRIPTION
This property is now on D-Bus can can be written into the CFAM-S off the local BMC like the other redundancy related properties are.

Tested:
cfamstool shows that the field correctly reflects the D-Bus value.

```
$ cfamstool -d
Local BMC CFAM-S scratchpad fields
API Version                0x1
BMC Position               0x0
Role                       xyz.openbmc_project.State.BMC.Redundancy.Role.Active
Redundancy Enabled         true
Failovers Paused           true <---------------
Provisioned                true
BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
Sibling Communication OK   true
Heartbeat                  0x1c
FW Version                 0xd5b96f97
```

Change-Id: Iab5a91f36b80940037aef1b6a56018796dbecde1