### PR TITLE
phal: Use error object for creating SBE error PEL

### DIFF
--- a/extensions/phal/create_pel.cpp
+++ b/extensions/phal/create_pel.cpp
@@ -8,7 +8,7 @@
 #include <libekb.H>
 #include <libphal.H>
 #include <unistd.h>
-
+#include <errl_factory.H>
 #include <phosphor-logging/elog.hpp>
 #include <xyz/openbmc_project/Logging/Create/server.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
@@ -34,7 +34,12 @@ namespace pel
 constexpr auto loggingObjectPath = "/xyz/openbmc_project/logging";
 constexpr auto loggingInterface = "xyz.openbmc_project.Logging.Create";
 constexpr auto opLoggingInterface = "org.open_power.Logging.PEL";
+using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
+namespace sdbus = sdbusplus::common::xyz::openbmc_project::logging;
 
+using FFDCInfo = std::vector<std::tuple<
+    sdbusplus::xyz::openbmc_project::Logging::server::Create::FFDCFormat,
+    uint8_t, uint8_t, sdbusplus::message::unix_fd>>;
 /**
  * @brief get SBE special callout information
  *
@@ -93,10 +98,7 @@ void createErrorPEL(const std::string& event, const json& calloutData,
     {
         FFDCFile ffdcFile(calloutData);
 
-        std::vector<std::tuple<sdbusplus::xyz::openbmc_project::Logging::
-                                   server::Create::FFDCFormat,
-                               uint8_t, uint8_t, sdbusplus::message::unix_fd>>
-            pelCalloutInfo;
+        FFDCInfo pelCalloutInfo;
 
         pelCalloutInfo.push_back(
             std::make_tuple(sdbusplus::xyz::openbmc_project::Logging::server::
@@ -148,10 +150,7 @@ uint32_t createSbeErrorPEL(const std::string& event, const sbeError_t& sbeError,
         additionalData.emplace(data);
     }
 
-    std::vector<std::tuple<
-        sdbusplus::xyz::openbmc_project::Logging::server::Create::FFDCFormat,
-        uint8_t, uint8_t, sdbusplus::message::unix_fd>>
-        pelFFDCInfo;
+    FFDCInfo pelFFDCInfo;
 
     // get SBE ffdc file descriptor
     auto fd = sbeError.getFd();
@@ -204,6 +203,84 @@ uint32_t createSbeErrorPEL(const std::string& event, const sbeError_t& sbeError,
 
     try
     {
+        std::string service =
+            util::getService(bus, loggingObjectPath, opLoggingInterface);
+        auto method =
+            bus.new_method_call(service.c_str(), loggingObjectPath,
+                                opLoggingInterface, "CreatePELWithFFDCFiles");
+        auto level =
+            sdbusplus::xyz::openbmc_project::Logging::server::convertForMessage(
+                severity);
+        method.append(event, level, additionalData, pelFFDCInfo);
+        auto response = bus.call(method);
+
+        // reply will be tuple containing bmc log id, platform log id
+        std::tuple<uint32_t, uint32_t> reply = {0, 0};
+
+        // parse dbus response into reply
+        response.read(reply);
+        plid = std::get<1>(reply); // platform log id is tuple "second"
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        log<level::ERR>(
+            std::format("D-Bus call exception",
+                        "OBJPATH={}, INTERFACE={}, EXCEPTION={}",
+                        loggingObjectPath, loggingInterface, e.what())
+                .c_str());
+        throw std::runtime_error(
+            "Error in invoking D-Bus logging create interface");
+    }
+    catch (const std::exception& e)
+    {
+        throw e;
+    }
+    return plid;
+}
+
+inline sdbus::Create::FFDCFormat toFFDCFormat(errl::FFDCFormat format)
+{
+    using FFDCFormat = sdbus::Create::FFDCFormat;
+
+    switch (format)
+    {
+        case errl::FFDCFormat::JSON:
+            return FFDCFormat::JSON;
+        case errl::FFDCFormat::CBOR:
+            return FFDCFormat::CBOR;
+        case errl::FFDCFormat::Text:
+            return FFDCFormat::Text;
+        case errl::FFDCFormat::Custom:
+            return FFDCFormat::Custom;
+        default:
+            throw std::invalid_argument("Invalid UserDataFormat enum value");
+    }
+}
+
+uint32_t createPstSbeErrorPEL(const errl::ErrlEntry* errlEntry)
+{
+    uint32_t plid = 0;
+    auto bus = sdbusplus::bus::new_default();
+
+    const auto& event = errlEntry->getMessage();
+    const auto& ffdcFileOpt = errlEntry->getFfdcFiles();
+
+    const auto& additionalData = errlEntry->getAdditionalData();
+
+    FFDCInfo pelFFDCInfo;
+    if (ffdcFileOpt)
+    {
+        for (const auto& pair : *ffdcFileOpt)
+        {
+            const auto& pelFfdc = pair.first;
+            pelFFDCInfo.emplace_back(
+                std::make_tuple(toFFDCFormat(pelFfdc.format), pelFfdc.subType,
+                                pelFfdc.version, pelFfdc.fd));
+        }
+    }
+    try
+    {
+        const Severity severity = Severity::Error;
         std::string service =
             util::getService(bus, loggingObjectPath, opLoggingInterface);
         auto method =

--- a/extensions/phal/create_pel.hpp
+++ b/extensions/phal/create_pel.hpp
@@ -3,6 +3,7 @@
 #include "xyz/openbmc_project/Logging/Entry/server.hpp"
 
 #include <phal_exception.H>
+#include <errl_entry.H>
 
 #include <nlohmann/json.hpp>
 
@@ -50,6 +51,7 @@ uint32_t createSbeErrorPEL(const std::string& event, const sbeError_t& sbeError,
                            struct pdbg_target* procTarget,
                            const Severity severity = Severity::Error);
 
+uint32_t createPstSbeErrorPEL(const errl::ErrlEntry* errlEntry);
 /**
  * @brief Create a PEL for the specified event type and additional data
  *

--- a/extensions/phal/phal_error.cpp
+++ b/extensions/phal/phal_error.cpp
@@ -12,6 +12,7 @@ extern "C"
 #include <attributes_info.H>
 #include <libekb.H>
 #include <libphal.H>
+#include <errl_factory.H>
 
 #include <nlohmann/json.hpp>
 #include <phosphor-logging/elog.hpp>
@@ -888,19 +889,22 @@ void processSbeBootError()
         procTarget = nullptr;
     }
     // check valid primary processor is available
+    uint32_t logId = 0;
     if (procTarget == nullptr)
     {
         log<level::ERR>("processSbeBootError: fail to get primary processor");
-        // Add BMC code callout and create PEL
-        json jsonCalloutDataList;
-        jsonCalloutDataList = json::array();
-        json jsonCalloutData;
-        jsonCalloutData["Procedure"] = "BMC0001";
-        jsonCalloutData["Priority"] = "H";
-        jsonCalloutDataList.emplace_back(jsonCalloutData);
-        openpower::pel::createErrorPEL(
-            "org.open_power.Processor.Error.SbeBootFailure",
-            jsonCalloutDataList, {}, Severity::Error);
+        auto errlHandle = errl::factory::createSbeNoFuncProc();
+        if (errlHandle && *errlHandle)
+        {
+            const auto& entries = (*errlHandle)->getEntries();
+            for (const auto& entryPtr : entries)
+            {
+                if (entryPtr)
+                {
+                    logId = openpower::pel::createPstSbeErrorPEL(entryPtr.get());
+                }
+            }
+        }
         return;
     }
     // SBE error object.
@@ -910,7 +914,18 @@ void processSbeBootError()
     try
     {
         // Capture FFDC information on primary processor
-        sbeError = captureFFDC(procTarget);
+        auto errlHandle = errl::factory::createSbeBootFailure(procTarget);
+        if (errlHandle && *errlHandle)
+        {
+            const auto& entries = (*errlHandle)->getEntries();
+            for (const auto& entryPtr : entries)
+            {
+                if (entryPtr)
+                {
+                    logId = openpower::pel::createPstSbeErrorPEL(entryPtr.get());
+                }
+            }
+        }
     }
     catch (const phalError_t& phalError)
     {
@@ -933,16 +948,10 @@ void processSbeBootError()
     {
         event = "org.open_power.Processor.Error.SbeBootFailure";
     }
-    // SRC6 : [0:15] chip position
-    uint32_t index = pdbg_target_index(procTarget);
-    pelAdditionalData.emplace_back("SRC6", std::to_string(index << 16));
-    // Create SBE Error with FFDC data.
-    auto logId =
-        createSbeErrorPEL(event, sbeError, pelAdditionalData, procTarget);
-
     if (dumpIsRequired)
     {
         using namespace openpower::phal::dump;
+        uint32_t index = pdbg_target_index(procTarget);
         DumpParameters dumpParameters = {logId, index, SBE_DUMP_TIMEOUT,
                                          DumpType::SBE};
         try


### PR DESCRIPTION
Refactor SBE boot failure handling to use the error object for PEL creation. The host firmware repository will now collect FFDC and capture it in an ErrlHandle object, which the caller must use to create PELs.

This avoids duplicating FFDC collection and PEL generation logic across multiple repositories and ensures consistent error handling for SBE-related failures.

Change-Id: I794174aa2359f5d63fc3de11d2657e506e5dae08