### PR TITLE
CFAM: Use separate sibling D-Bus ifaces

### DIFF
--- a/rbmc-cfam-daemon/src/services.cpp
+++ b/rbmc-cfam-daemon/src/services.cpp
@@ -14,6 +14,7 @@
 namespace state_ns = sdbusplus::common::xyz::openbmc_project::state;
 namespace bmc_ns = sdbusplus::common::xyz::openbmc_project::state::bmc;
 namespace rules = sdbusplus::bus::match::rules;
+using RedNSPath = bmc_ns::Redundancy::namespace_path;
 
 namespace util
 {
@@ -43,8 +44,11 @@ Services::Services(sdbusplus::async::context& ctx,
                    RedEnabledCallback&& redEnabledCallback,
                    FailoversAllowedCallback&& failoversAllowedCallback) :
     ctx(ctx), bmcStateCallback(std::move(stateCallback)),
-    roleCallback(roleCallback), redEnabledCallback(redEnabledCallback),
-    failoversAllowedCallback(failoversAllowedCallback)
+    roleCallback(std::move(roleCallback)),
+    redEnabledCallback(std::move(redEnabledCallback)),
+    failoversAllowedCallback(std::move(failoversAllowedCallback)),
+    localBMCPath(
+        sdbusplus::message::object_path{RedNSPath::value} / RedNSPath::bmc)
 {
     startup();
 }
@@ -133,46 +137,38 @@ uint32_t Services::getBMCPosition()
 
 sdbusplus::async::task<Services::BMCState> Services::getBMCState()
 {
-    using np = state_ns::BMC::namespace_path;
-    std::string objectPath =
-        sdbusplus::message::object_path(np::value) / np::bmc;
-
     auto service =
-        co_await util::getService(ctx, objectPath, state_ns::BMC::interface);
+        co_await util::getService(ctx, localBMCPath, state_ns::BMC::interface);
 
     using StateMgr = sdbusplus::client::xyz::openbmc_project::state::BMC<>;
-    auto stateMgr = StateMgr(ctx).service(service).path(objectPath);
-    co_return co_await stateMgr.current_bmc_state();
+    co_return co_await StateMgr(ctx)
+        .service(service)
+        .path(localBMCPath)
+        .current_bmc_state();
 }
 
 sdbusplus::async::task<std::tuple<Services::Role, bool, bool>>
     Services::getRedundancyProps()
 {
-    auto service = co_await util::getService(
-        ctx, bmc_ns::Redundancy::instance_path, bmc_ns::Redundancy::interface);
+    auto service = co_await util::getService(ctx, localBMCPath,
+                                             bmc_ns::Redundancy::interface);
 
-    auto rbmcMgr = sdbusplus::async::proxy()
-                       .service(service)
-                       .path(bmc_ns::Redundancy::instance_path)
-                       .interface(bmc_ns::Redundancy::interface);
+    using Redundancy =
+        sdbusplus::client::xyz::openbmc_project::state::bmc::Redundancy<>;
 
-    auto props =
-        co_await rbmcMgr
-            .get_all_properties<bmc_ns::Redundancy::PropertiesVariant>(ctx);
-    auto role = std::get<Role>(props.at("Role"));
-    auto enabled = std::get<bool>(props.at("RedundancyEnabled"));
-    auto allowed = std::get<bool>(props.at("FailoversAllowed"));
-    co_return std::make_tuple(role, enabled, allowed);
+    auto props = co_await Redundancy(ctx)
+                     .service(service)
+                     .path(localBMCPath)
+                     .properties();
+
+    co_return std::make_tuple(props.role, props.redundancy_enabled,
+                              props.failovers_allowed);
 }
 
 sdbusplus::async::task<> Services::watchBMCStateProp()
 {
-    using np = state_ns::BMC::namespace_path;
-    std::string objectPath =
-        sdbusplus::message::object_path(np::value) / np::bmc;
-
     sdbusplus::async::match match(
-        ctx, rules::propertiesChanged(objectPath, state_ns::BMC::interface));
+        ctx, rules::propertiesChanged(localBMCPath, state_ns::BMC::interface));
 
     using PropertyMap = std::map<std::string, state_ns::BMC::PropertiesVariant>;
 
@@ -187,14 +183,13 @@ sdbusplus::async::task<> Services::watchBMCStateProp()
             bmcStateCallback(std::get<BMCState>(it->second));
         }
     }
-    co_return;
 }
 
 sdbusplus::async::task<> Services::watchRedundancyProps()
 {
     sdbusplus::async::match match(
-        ctx, rules::propertiesChanged(bmc_ns::Redundancy::instance_path,
-                                      bmc_ns::Redundancy::interface));
+        ctx,
+        rules::propertiesChanged(localBMCPath, bmc_ns::Redundancy::interface));
 
     using PropertyMap =
         std::map<std::string, bmc_ns::Redundancy::PropertiesVariant>;
@@ -222,19 +217,13 @@ sdbusplus::async::task<> Services::watchRedundancyProps()
             failoversAllowedCallback(std::get<bool>(it->second));
         }
     }
-    co_return;
 }
 
 sdbusplus::async::task<> Services::watchBMCInterfaceAdded()
 {
-    namespace rules = sdbusplus::bus::match::rules;
-    using np = state_ns::BMC::namespace_path;
-    std::string objectPath =
-        sdbusplus::message::object_path(np::value) / np::bmc;
-
     // Note: BMC State and Redundancy are on the same object path
     sdbusplus::async::match match(ctx,
-                                  rules::interfacesAddedAtPath(objectPath));
+                                  rules::interfacesAddedAtPath(localBMCPath));
 
     using PropertiesVariant = std::variant<std::string, state_ns::BMC::BMCState,
                                            bmc_ns::Redundancy::Role, bool>;
@@ -282,6 +271,4 @@ sdbusplus::async::task<> Services::watchBMCInterfaceAdded()
             }
         }
     }
-
-    co_return;
 }

--- a/rbmc-cfam-daemon/src/services.hpp
+++ b/rbmc-cfam-daemon/src/services.hpp
@@ -138,4 +138,9 @@ class Services
      * @brief The callback function for FailoversAllowed
      */
     FailoversAllowedCallback failoversAllowedCallback;
+
+    /**
+     * @brief Object path for this BMC's redundancy and state interfaces.
+     */
+    std::string localBMCPath;
 };

--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -7,7 +7,7 @@
 
 void SiblingBMC::read()
 {
-    bool createdIface = false;
+    bool createdObject = false;
 
     if (!cfam.isReady())
     {
@@ -17,10 +17,12 @@ void SiblingBMC::read()
             ready = false;
         }
 
-        if (siblingInterface)
+        if (siblingObject)
         {
             lg2::info(
-                "Removing sibling interface from D-Bus due to CFAM not ready");
+                "Removing sibling object from D-Bus due to CFAM not ready");
+            siblingObject.reset();
+
             siblingInterface.reset();
         }
         return;
@@ -36,52 +38,71 @@ void SiblingBMC::read()
 
     if (cfam.hasError())
     {
-        if (siblingInterface)
+        if (siblingObject)
         {
-            lg2::info("Removing sibling API from D-Bus due to CFAM error");
+            lg2::info("Removing sibling object from D-Bus due to CFAM error");
+            siblingObject.reset();
+
             siblingInterface.reset();
         }
         return;
     }
 
-    if (!siblingInterface)
+    if (!siblingObject)
     {
-        lg2::info("Creating Sibling D-Bus interface");
+        lg2::info("Creating Sibling D-Bus interfaces");
 
         auto objectPath =
-            sdbusplus::message::object_path{
-                SiblingInterface::namespace_path::value} /
-            SiblingInterface::namespace_path::bmc;
+            sdbusplus::message::object_path{RedIntf::namespace_path::value} /
+            RedIntf::namespace_path::sibling_bmc;
+
+        siblingObject =
+            std::make_unique<SiblingObject>(ctx.get_bus(), objectPath.str);
 
         siblingInterface = std::make_unique<SiblingInterface>(
             ctx.get_bus(), objectPath.str.c_str(),
             SiblingInterface::action::defer_emit);
 
-        createdIface = true;
+        createdObject = true;
     }
 
-    siblingInterface->communicationOK(cfam.getSiblingCommsOK(), createdIface);
-    siblingInterface->bmcPosition(cfam.getBMCPosition(), createdIface);
-    siblingInterface->provisioned(cfam.getProvisioned(), createdIface);
-    siblingInterface->role(cfam.getRole(), createdIface);
-    siblingInterface->redundancyEnabled(cfam.getRedundancyEnabled(),
-                                        createdIface);
-    siblingInterface->failoversAllowed(cfam.getFailoversAllowed(),
-                                       createdIface);
-    siblingInterface->bmcState(cfam.getBMCState(), createdIface);
+    siblingObject->role(cfam.getRole(), createdObject);
+    siblingObject->redundancyEnabled(cfam.getRedundancyEnabled(),
+                                     createdObject);
+    siblingObject->failoversAllowed(cfam.getFailoversAllowed(), createdObject);
+    siblingObject->currentBMCState(cfam.getBMCState(), createdObject);
 
     auto version = std::format("{:X}", cfam.getFWVersion());
-    siblingInterface->fwVersion(version, createdIface);
+    siblingObject->version(version, createdObject);
 
     // Must detect a heartbeat change to consider it active, so it won't
     // be active until at least the second time though.
     auto heartbeat = cfam.getHeartbeat();
     auto alive = lastHeartbeat.has_value() &&
                  (heartbeat != lastHeartbeat.value());
-    siblingInterface->heartbeat(alive, createdIface);
+    siblingObject->active(alive, createdObject);
     lastHeartbeat = heartbeat;
 
-    if (createdIface)
+    if (createdObject)
+    {
+        siblingObject->emit_object_added();
+    }
+
+    siblingInterface->communicationOK(cfam.getSiblingCommsOK(), createdObject);
+    siblingInterface->bmcPosition(cfam.getBMCPosition(), createdObject);
+    siblingInterface->provisioned(cfam.getProvisioned(), createdObject);
+    siblingInterface->role(cfam.getRole(), createdObject);
+    siblingInterface->redundancyEnabled(cfam.getRedundancyEnabled(),
+                                        createdObject);
+    siblingInterface->failoversAllowed(cfam.getFailoversAllowed(),
+                                       createdObject);
+    siblingInterface->bmcState(cfam.getBMCState(), createdObject);
+
+    siblingInterface->fwVersion(version, createdObject);
+
+    siblingInterface->heartbeat(alive, createdObject);
+
+    if (createdObject)
     {
         siblingInterface->emit_object_added();
     }

--- a/rbmc-cfam-daemon/src/sibling_bmc.hpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 #include "sibling_cfam.hpp"
+#include "sibling_object.hpp"
 
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/Sibling/server.hpp>
@@ -24,7 +25,6 @@ class SiblingBMC
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
 
-    SiblingBMC() = delete;
     ~SiblingBMC() = default;
     SiblingBMC(const SiblingBMC&) = delete;
     SiblingBMC& operator=(const SiblingBMC&) = delete;
@@ -75,6 +75,11 @@ class SiblingBMC
      * @brief The Sibling D-Bus interface
      */
     std::unique_ptr<SiblingInterface> siblingInterface;
+
+    /**
+     * @brief The Sibling D-Bus object
+     */
+    std::unique_ptr<SiblingObject> siblingObject;
 
     /**
      * @brief The last heartbeat value read from the CFAM.

--- a/rbmc-cfam-daemon/src/sibling_object.hpp
+++ b/rbmc-cfam-daemon/src/sibling_object.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <xyz/openbmc_project/Software/Version/server.hpp>
+#include <xyz/openbmc_project/State/BMC/Redundancy/server.hpp>
+#include <xyz/openbmc_project/State/BMC/server.hpp>
+#include <xyz/openbmc_project/State/Decorator/Heartbeat/server.hpp>
+
+using RedIntf = sdbusplus::server::xyz::openbmc_project::state::bmc::Redundancy;
+using HBIntf =
+    sdbusplus::server::xyz::openbmc_project::state::decorator::Heartbeat;
+using VersionIntf = sdbusplus::server::xyz::openbmc_project::software::Version;
+using StateIntf = sdbusplus::server::xyz::openbmc_project::state::BMC;
+
+using SiblingInterfaces =
+    sdbusplus::server::object_t<RedIntf, HBIntf, VersionIntf, StateIntf>;
+
+/**
+ * @class SiblingObject
+ *
+ * The D-Bus object that holds the sibling BMC's values.
+ *
+ * Note: This isn't the async version because the code needs to
+ * conditionally specify if a PC signal should be emitted,
+ * and the only way to do that with the async version is with
+ * a template param, e.g. obj->role<true>(val)
+ */
+class SiblingObject : public SiblingInterfaces
+{
+  public:
+    SiblingObject(const SiblingObject&) = delete;
+    SiblingObject& operator=(const SiblingObject&) = delete;
+    SiblingObject(SiblingObject&&) = delete;
+    SiblingObject& operator=(SiblingObject&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] bus - The sdbusplus bus object
+     * @param[in] path - Object path
+     */
+    SiblingObject(sdbusplus::bus_t& bus, const std::string& path) :
+        SiblingInterfaces(bus, path.c_str(), action::defer_emit)
+    {}
+
+    // Don't allow writes
+    bool disableRedundancyOverride(bool) override
+    {
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+
+    // Don't allow writes
+    Transition requestedBMCTransition(Transition) override
+    {
+        throw sdbusplus::xyz::openbmc_project::Common::Error::Unavailable();
+    }
+};


### PR DESCRIPTION
Instead of using the 'xyz.openbmc_project.State.BMC.Redundancy.Sibling' interface to hold every D-Bus property the sibling BMC needs, use separate interfaces to hold the properties so that one property isn't located in 2 different interfaces.

The interfaces are:
 - xyz.openbmc_project.State.BMC.Redundancy
 - xyz.openbmc_project.State.BMC
 - xyz.openbmc_project.Software.Version
 - xyz.openbmc_project.State.Decorator.Heartbeat

This does mean there are some unused extra properties, but there isn't really anything that can be done about that.

The Purpose property on the Version interface is 'Unknown' instead of 'BMC' just to make sure it doesn't confuse anyone looking for the real BMC version.

There are also some properties that are no longer available:
- Sibling provisioned
- Sibling BMC position
- Sibling has good sibling communication

The Provisioned property will be added back in the future on a real provisioning interface when there is a real need for it, and the other two are being deprecated by the RBMC manager.

The original Sibling interface is still left how it is for now, to give users a chance to move to these new ones.

A new sibling_object.hpp was created to hold the object for the four interfaces.  It does override the DisableRedundancyOverride and RequestedBMCTransition properties to throw the 'Unavailable' D-Bus error on a write attempt since modifying those isn't supported on this object and they already have that error defined their YAML definition.

There are also a few other modernizations made to the Services class.

Tested:
All interfaces show up:

```
busctl introspect xyz.openbmc_project.State.BMC.Redundancy.Sibling /xyz/openbmc_project/state/bmc1 -l

xyz.openbmc_project.Software.Version             interface -         -                          -
.Purpose                                         property  s         "xyz.openbmc_project.Software.Version.VersionPurpose.Unknown"
.Version                                         property  s         "7969307F"

xyz.openbmc_project.State.BMC                    interface -         -
.CurrentBMCState                                 property  s         "xyz.openbmc_project.State.BMC.BMCState.Ready"
.LastRebootCause                                 property  s         "xyz.openbmc_project.State.BMC.RebootCause.Unknown"
.LastRebootTime                                  property  t         0
.RequestedBMCTransition                          property  s         "xyz.openbmc_project.State.BMC.Transition.None"

xyz.openbmc_project.State.BMC.Redundancy         interface -         -
.DisableRedundancyOverride                       property  b         false
.FailoversAllowed                                property  b         true
.RedundancyEnabled                               property  b         true
.Role                                            property  s         "xyz.openbmc_project.State.BMC.Redundancy.Role.Passive"
.Heartbeat                                       signal    -         -

xyz.openbmc_project.State.BMC.Redundancy.Sibling interface -         -
.BMCPositionproperty  u         1
.BMCState                                        property  s         "xyz.openbmc_project.State.BMC.BMCState.Ready"
.CommunicationOK                                 property  b         true
.FWVersion                                       property  s         "7969307F"
.FailoversAllowed                                property  b         true
.Heartbeat                                       property  b         true
.Provisioned                property  b         true
.RedundancyEnabled                               property  b         true
.Role                                            property  s         "xyz.openbmc_project.State.BMC.Redundancy.Role.Passive"

xyz.openbmc_project.State.Decorator.Heartbeat    interface -         -
.Active                                          property  b         true

```

Change-Id: I02596653188338306f132f804606416f06face53