### PR TITLE
CFAM: Sibling BMC FW version should be 8 digits

### DIFF
--- a/procedures/phal/enter_mpreboot.cpp
+++ b/procedures/phal/enter_mpreboot.cpp
@@ -143,7 +143,7 @@ void enterMpReboot()
 
     pdbg_set_loglevel(PDBG_NOTICE);
 
-    if(!pdbg_targets_init(NULL))
+    if (!pdbg_targets_init(NULL))
     {
         log<level::ERR>("pdbg target init failed");
         openpower::pel::createPEL("org.open_power.PHAL.Error.MPReboot");
@@ -162,7 +162,8 @@ void enterMpReboot()
         if (!hwasState.functional)
         {
             log<level::INFO>(std::format("proc({}) is not functional",
-                             pdbg_target_index(target)).c_str());
+                                         pdbg_target_index(target))
+                                 .c_str());
             continue;
         }
 

--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -72,7 +72,7 @@ void SiblingBMC::read()
     siblingObject->failoversAllowed(cfam.getFailoversAllowed(), createdObject);
     siblingObject->currentBMCState(cfam.getBMCState(), createdObject);
 
-    auto version = std::format("{:X}", cfam.getFWVersion());
+    auto version = std::format("{:08X}", cfam.getFWVersion());
     siblingObject->version(version, createdObject);
 
     // Must detect a heartbeat change to consider it active, so it won't


### PR DESCRIPTION
The Version property for the sibling BMC was losing leading zeros, causing a mismatch with what the redundancy daemon uses.  This caused the code to disable redundancy because it thinks there is a version mismatch.

Tested:

Before, no leading zero:
```
xyz.openbmc_project.Software.Version       interface
.Version property  s "9C4F489"
```

With fix, now has leading zero:
```
xyz.openbmc_project.Software.Version       interface
.Version property  s "09C4F489"
```

Change-Id: I5fe7a051b20edaf82a68d5c9b0743a44894d467d