### PR TITLE
utilize systemd semantic for non-critical ExecStart

### DIFF
--- a/service_files/op-enter-mpreboot@.service.in
+++ b/service_files/op-enter-mpreboot@.service.in
@@ -15,15 +15,14 @@ Conflicts=obmc-host-startmin@%i.target
 @ENABLE_PHAL_TRUE@Environment="PDBG_DTB=@CEC_DEVTREE_RW_PATH@"
 RemainAfterExit=yes
 Type=oneshot
-ExecStart=+/bin/sh -c \
+ExecStart=-/bin/sh -c \
   "busctl set-property xyz.openbmc_project.BIOSConfigManager \
    /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager \
    PendingAttributes a{s\\(sv\\)} 1 pvm_sys_dump_active \
-   xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration s Enabled" \
-   || true
-ExecStart=+/bin/sh -c \
+   xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration s Enabled"
+ExecStart=-/bin/sh -c \
   "busctl call  xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/bmc \
-   xyz.openbmc_project.Dump.Create CreateDump a{sv} 0"  || true
+   xyz.openbmc_project.Dump.Create CreateDump a{sv} 0"
 ExecStart=/usr/bin/openpower-proc-control enterMpReboot
 ExecStart=/bin/mkdir -p /run/openbmc/
 ExecStart=/bin/touch /run/openbmc/mpreboot@%i

--- a/service_files/op-stop-instructions@.service.in
+++ b/service_files/op-stop-instructions@.service.in
@@ -13,7 +13,7 @@ ConditionPathExists=!/run/openbmc/mpreboot@%i
 RemainAfterExit=yes
 Type=oneshot
 TimeoutStartSec=20
-ExecStart=/bin/sh -c 'systemctl stop attn_handler.service || true'
+ExecStart=-/bin/sh -c 'systemctl stop attn_handler.service'
 ExecStart=/usr/bin/openpower-proc-control threadStopAll
 
 [Install]


### PR DESCRIPTION
The "|| true" was always a bit of a hack to have systemd services ignore commands which are not critical. It seems recent systemd releases have broken that workaround.

Utilize the official[1] systemd mechanism to indicate a command within the service is optional and ok to fail (=-).

The location of the "|| true" within the commands quotation marks now matters. But lets just get rid of it all together now that we have a way to just have systemd allow the command to fail and continue.

Tested:
Wrote a little test service:
```
[Unit]
Description=Test Service

[Service]
RemainAfterExit=yes
Type=oneshot
ExecStart=/bin/sh -c "busctl set-property invalid || true"
ExecStart=-/bin/sh -c "busctl set-property invalid" || true
ExecStart=-/bin/sh -c "busctl set-property invalid"
ExecStart=/bin/echo 'we made it past all invalid tests above'

[Install]

```

[1]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines

Change-Id: I5b16a5abf9ba8e0a384bac1130b77bf0252b9dd9