### PR TITLE
CFAM: Support FailoverImminent field in CFAM

### DIFF
--- a/rbmc-cfam-daemon/README.md
+++ b/rbmc-cfam-daemon/README.md
@@ -29,7 +29,8 @@ The `rbmc-cfam-daemon` meson option will enable building this code.
 | Provisioned       | 1        | 13        | 1      |
 | BMC State         | 1        | 14        | 3      |
 | Sibling Comms OK  | 1        | 17        | 1      |
-| Reserved          | 1        | 18        | 6      |
+| Failover Imminent | 1        | 18        | 1      |
+| Reserved          | 1        | 19        | 5      |
 | Heartbeat         | 1        | 24        | 8      |
 | FW Version        | 2        | 0         | 32     |
 | Reserved          | 3        | 0         | 32     |
@@ -58,6 +59,9 @@ property from the BMC state daemon.
 
 **Sibling Comms OK**: If this BMC can read the sibling BMC's CFAM.
 
+**Failover Imminent**: If the sibling will start a failover soon. Only the
+passive BMC will set this, soon before it starts a failover to become active.
+
 **Heartbeat**: This field is incremented by one every time the CFAM application
 receives the Heartbeat signal from the RBMC state manager application. This can
 be used by the sibling to know the management daemon is alive.
@@ -80,6 +84,7 @@ Failovers Allowed          true
 Provisioned                true
 BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
 Sibling Communication OK   true
+Failover Imminent          false
 Heartbeat                  0x25
 FW Version                 0x1c9c4045
 
@@ -92,6 +97,7 @@ Failovers Allowed          true
 Provisioned                true
 BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
 Sibling Communication OK   true
+Failover Imminent          false
 Heartbeat                  0x24
 FW Version                 0x1c9c4045
 ```

--- a/rbmc-cfam-daemon/src/bmc_cfam.hpp
+++ b/rbmc-cfam-daemon/src/bmc_cfam.hpp
@@ -34,6 +34,7 @@ class BMCCFAM
         provisioned,
         bmcState,
         siblingCommsOK,
+        failoverImminent,
         heartbeat,
         fwVersion
     };
@@ -53,6 +54,8 @@ class BMCCFAM
         {Field::bmcState, {cfam::ScratchPadReg::one, 14, 3, "BMC State"}},
         {Field::siblingCommsOK,
          {cfam::ScratchPadReg::one, 17, 1, "Sibling Communication OK"}},
+        {Field::failoverImminent,
+         {cfam::ScratchPadReg::one, 18, 1, "Failover Imminent"}},
         {Field::heartbeat, {cfam::ScratchPadReg::one, 24, 8, "Heartbeat"}},
         {Field::fwVersion, {cfam::ScratchPadReg::two, 0, 32, "FW Version"}}};
 

--- a/rbmc-cfam-daemon/src/cfams_tool.cpp
+++ b/rbmc-cfam-daemon/src/cfams_tool.cpp
@@ -29,6 +29,7 @@ std::string formatValue(BMCCFAM::Field field, uint32_t value)
         case failoversAllowed:
         case provisioned:
         case siblingCommsOK:
+        case failoverImminent:
             result = std::format("{}", value ? "true" : "false");
             break;
         case role:

--- a/rbmc-cfam-daemon/src/local_bmc.cpp
+++ b/rbmc-cfam-daemon/src/local_bmc.cpp
@@ -22,7 +22,8 @@ sdbusplus::async::task<> LocalBMC::start()
         ctx, [this](auto state) { bmcStateChanged(state); },
         [this](auto role) { roleChanged(role); },
         [this](auto enabled) { redEnabledChanged(enabled); },
-        [this](auto allowed) { failoversAllowedChanged(allowed); });
+        [this](auto allowed) { failoversAllowedChanged(allowed); },
+        [this](auto imminent) { failoverImminentChanged(imminent); });
 
     co_await writeRedundancyProps();
     co_await writeBMCState();
@@ -122,18 +123,28 @@ void LocalBMC::failoversAllowedChanged(bool allowed)
     cfam.writeFailoversAllowed(allowed);
 }
 
+void LocalBMC::failoverImminentChanged(bool imminent)
+{
+    lg2::info("Local Failover Imminent changed to {IMMINENT}", "IMMINENT",
+              imminent);
+    cfam.writeFailoverImminent(imminent);
+}
+
 sdbusplus::async::task<> LocalBMC::writeRedundancyProps()
 {
     try
     {
-        auto [role, enabled, allowed] = co_await services->getRedundancyProps();
+        auto [role, enabled, allowed,
+              imminent] = co_await services->getRedundancyProps();
         lg2::info(
-            "Initial values of local role, redEnabled, fo allowed: {ROLE} {ENABLED} {ALLOWED}",
-            "ROLE", role, "ENABLED", enabled, "ALLOWED", allowed);
+            "Initial values of local role, redEnabled, fo allowed, fo imminent: {ROLE} {ENABLED} {ALLOWED} {IMMINENT}",
+            "ROLE", role, "ENABLED", enabled, "ALLOWED", allowed, "IMMINENT",
+            imminent);
 
         cfam.writeRole(role);
         cfam.writeRedundancyEnabled(enabled);
         cfam.writeFailoversAllowed(allowed);
+        cfam.writeFailoverImminent(imminent);
     }
     catch (const sdbusplus::exception_t& e)
     {

--- a/rbmc-cfam-daemon/src/local_bmc.hpp
+++ b/rbmc-cfam-daemon/src/local_bmc.hpp
@@ -139,6 +139,17 @@ class LocalBMC
     void failoversAllowedChanged(bool allowed);
 
     /**
+     * @brief Callback function for when the failover
+     * imminent D-Bus property changes.
+     *
+     * Writes the new value into the CFAM in the
+     * FailoverImminent field.
+     *
+     * @param[in] imminent - the value to write
+     */
+    void failoverImminentChanged(bool imminent);
+
+    /**
      * @brief The context object
      */
     sdbusplus::async::context& ctx;

--- a/rbmc-cfam-daemon/src/local_cfam.cpp
+++ b/rbmc-cfam-daemon/src/local_cfam.cpp
@@ -126,6 +126,17 @@ void LocalCFAM::writeSiblingCommsOK(bool ok)
     }
 }
 
+void LocalCFAM::writeFailoverImminent(bool imminent)
+{
+    auto rc = writeField(Field::failoverImminent, imminent);
+    if (rc != 0)
+    {
+        lg2::error("Failed writing Failover Imminent field {IMM} in local CFAM",
+                   "IMM", imminent);
+        throw std::system_error(rc, std::generic_category());
+    }
+}
+
 std::expected<uint32_t, int> LocalCFAM::readField(Field field)
 {
     auto data = cfamAccess.readScratchReg(cfamFields.at(field).reg);

--- a/rbmc-cfam-daemon/src/local_cfam.hpp
+++ b/rbmc-cfam-daemon/src/local_cfam.hpp
@@ -121,6 +121,13 @@ class LocalCFAM : public BMCCFAM
     void writeSiblingCommsOK(bool ok);
 
     /**
+     * @brief Writes the failover imminent field into the CFAM
+     *
+     * @param[in] imminent - If a failover is imminent
+     */
+    void writeFailoverImminent(bool imminent);
+
+    /**
      * @brief Increments the heartbeat field in the CFAM
      */
     void incHeartbeat();

--- a/rbmc-cfam-daemon/src/services.cpp
+++ b/rbmc-cfam-daemon/src/services.cpp
@@ -38,15 +38,16 @@ sdbusplus::async::task<std::string> getService(sdbusplus::async::context& ctx,
 
 } // namespace util
 
-Services::Services(sdbusplus::async::context& ctx,
-                   BMCStateCallback&& stateCallback,
-                   RoleCallback&& roleCallback,
-                   RedEnabledCallback&& redEnabledCallback,
-                   FailoversAllowedCallback&& failoversAllowedCallback) :
+Services::Services(
+    sdbusplus::async::context& ctx, BMCStateCallback&& stateCallback,
+    RoleCallback&& roleCallback, RedEnabledCallback&& redEnabledCallback,
+    FailoversAllowedCallback&& failoversAllowedCallback,
+    FailoverImminentCallback&& failoverImminentCallback) :
     ctx(ctx), bmcStateCallback(std::move(stateCallback)),
     roleCallback(std::move(roleCallback)),
     redEnabledCallback(std::move(redEnabledCallback)),
     failoversAllowedCallback(std::move(failoversAllowedCallback)),
+    failoverImminentCallback(std::move(failoverImminentCallback)),
     localBMCPath(
         sdbusplus::message::object_path{RedNSPath::value} / RedNSPath::bmc)
 {
@@ -147,7 +148,7 @@ sdbusplus::async::task<Services::BMCState> Services::getBMCState()
         .current_bmc_state();
 }
 
-sdbusplus::async::task<std::tuple<Services::Role, bool, bool>>
+sdbusplus::async::task<std::tuple<Services::Role, bool, bool, bool>>
     Services::getRedundancyProps()
 {
     auto service = co_await util::getService(ctx, localBMCPath,
@@ -162,7 +163,7 @@ sdbusplus::async::task<std::tuple<Services::Role, bool, bool>>
                      .properties();
 
     co_return std::make_tuple(props.role, props.redundancy_enabled,
-                              props.failovers_allowed);
+                              props.failovers_allowed, props.failover_imminent);
 }
 
 sdbusplus::async::task<> Services::watchBMCStateProp()
@@ -216,6 +217,12 @@ sdbusplus::async::task<> Services::watchRedundancyProps()
         {
             failoversAllowedCallback(std::get<bool>(it->second));
         }
+
+        it = propertyMap.find("FailoverImminent");
+        if (it != propertyMap.end())
+        {
+            failoverImminentCallback(std::get<bool>(it->second));
+        }
     }
 }
 
@@ -268,6 +275,12 @@ sdbusplus::async::task<> Services::watchBMCInterfaceAdded()
             if (propIt != props.end())
             {
                 failoversAllowedCallback(std::get<bool>(propIt->second));
+            }
+
+            propIt = props.find("FailoverImminent");
+            if (propIt != props.end())
+            {
+                failoverImminentCallback(std::get<bool>(propIt->second));
             }
         }
     }

--- a/rbmc-cfam-daemon/src/services.hpp
+++ b/rbmc-cfam-daemon/src/services.hpp
@@ -24,6 +24,7 @@ class Services
     using RoleCallback = std::function<void(Role)>;
     using RedEnabledCallback = std::function<void(bool)>;
     using FailoversAllowedCallback = std::function<void(bool)>;
+    using FailoverImminentCallback = std::function<void(bool)>;
 
     Services() = delete;
     ~Services() = default;
@@ -44,11 +45,14 @@ class Services
      *                                 redundancyEnabled prop changes
      * @param[in] failoversAllowedCallback - Function to run when this prop
      *                                      changes
+     * @param[in] failoverImminentCallback - Function to run when this
+     *                                         prop changes
      */
     Services(sdbusplus::async::context& ctx, BMCStateCallback&& stateCallback,
              RoleCallback&& roleCallback,
              RedEnabledCallback&& redEnabledCallback,
-             FailoversAllowedCallback&& failoversAllowedCallback);
+             FailoversAllowedCallback&& failoversAllowedCallback,
+             FailoverImminentCallback&& failoverImminentCallback);
 
     /**
      * @brief Reads the CurrentBMCState property
@@ -60,9 +64,10 @@ class Services
     /**
      * @brief Reads the role and redundancyEnabled properties
      *
-     * @return - A tuple of the role and redundancyEnabled property
+     * @return - A tuple of role, redundancyEnabled, FailoversAllowed
+     *           FailoverImminent
      */
-    sdbusplus::async::task<std::tuple<Services::Role, bool, bool>>
+    sdbusplus::async::task<std::tuple<Services::Role, bool, bool, bool>>
         getRedundancyProps();
 
     /**
@@ -138,6 +143,11 @@ class Services
      * @brief The callback function for FailoversAllowed
      */
     FailoversAllowedCallback failoversAllowedCallback;
+
+    /**
+     * @brief The callback function for FailoverImminent
+     */
+    FailoverImminentCallback failoverImminentCallback;
 
     /**
      * @brief Object path for this BMC's redundancy and state interfaces.

--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -71,6 +71,7 @@ void SiblingBMC::read()
                                      createdObject);
     siblingObject->failoversAllowed(cfam.getFailoversAllowed(), createdObject);
     siblingObject->currentBMCState(cfam.getBMCState(), createdObject);
+    siblingObject->failoverImminent(cfam.getFailoverImminent(), createdObject);
 
     auto version = std::format("{:08X}", cfam.getFWVersion());
     siblingObject->version(version, createdObject);

--- a/rbmc-cfam-daemon/src/sibling_cfam.cpp
+++ b/rbmc-cfam-daemon/src/sibling_cfam.cpp
@@ -39,6 +39,9 @@ void SiblingCFAM::readAll()
 
     siblingCommsOK =
         cfam::getFieldValue(*regs, cfamFields.at(Field::siblingCommsOK));
+
+    failoverImminent =
+        cfam::getFieldValue(*regs, cfamFields.at(Field::failoverImminent));
 }
 
 uint8_t SiblingCFAM::getApiVersion() const
@@ -120,6 +123,15 @@ bool SiblingCFAM::getSiblingCommsOK() const
         throw std::runtime_error{"CFAM fields not available"};
     }
     return siblingCommsOK;
+}
+
+bool SiblingCFAM::getFailoverImminent() const
+{
+    if (error)
+    {
+        throw std::runtime_error{"CFAM fields not available"};
+    }
+    return failoverImminent;
 }
 
 uint32_t SiblingCFAM::getHeartbeat() const

--- a/rbmc-cfam-daemon/src/sibling_cfam.hpp
+++ b/rbmc-cfam-daemon/src/sibling_cfam.hpp
@@ -106,6 +106,13 @@ class SiblingCFAM : public BMCCFAM
     bool getSiblingCommsOK() const;
 
     /**
+     * @brief Returns the failover imminent field
+     *
+     * Will throw if there is a hardware error
+     */
+    bool getFailoverImminent() const;
+
+    /**
      * @brief Returns the heartbeat field
      *
      * Will throw if there is a hardware error
@@ -157,6 +164,9 @@ class SiblingCFAM : public BMCCFAM
 
     /** @brief Latest sibling comms OK value */
     bool siblingCommsOK{};
+
+    /** @brief Latest failover imminent value */
+    bool failoverImminent{};
 
     /** @brief The set of scratchpad regs that contain field */
     std::set<cfam::ScratchPadReg> usedRegs;

--- a/rbmc-cfam-daemon/test/sibling_cfam_test.cpp
+++ b/rbmc-cfam-daemon/test/sibling_cfam_test.cpp
@@ -18,7 +18,7 @@ TEST_F(SiblingCFAMTest, TestReads)
     SiblingCFAM sibling{1, driver};
 
     EXPECT_CALL(driver, read(link1Device, 0))
-        .WillOnce(Return(Expected(0x01DDFFFF)));
+        .WillOnce(Return(Expected(0x01DDEFFF)));
     EXPECT_CALL(driver, read(link1Device, 1))
         .WillOnce(Return(Expected(0x12345678)));
 
@@ -40,6 +40,7 @@ TEST_F(SiblingCFAMTest, TestReads)
     EXPECT_EQ(sibling.getSiblingCommsOK(), true);
     EXPECT_EQ(sibling.getHeartbeat(), 0xFF);
     EXPECT_EQ(sibling.getFWVersion(), 0x12345678);
+    EXPECT_EQ(sibling.getFailoverImminent(), true);
 }
 
 TEST_F(SiblingCFAMTest, TestReadFail)
@@ -65,4 +66,5 @@ TEST_F(SiblingCFAMTest, TestReadFail)
     EXPECT_THROW(sibling.getRole(), std::runtime_error);
     EXPECT_THROW(sibling.getSiblingCommsOK(), std::runtime_error);
     EXPECT_THROW(sibling.getHeartbeat(), std::runtime_error);
+    EXPECT_THROW(sibling.getFailoverImminent(), std::runtime_error);
 }


### PR DESCRIPTION
This new field is used so that one BMC can tell that the other is starting a failover to allow it to prepare.  It will use bit 18 in the first scratchpad register.

Tested:
New unit tests pass

On D-Bus:
```
$ busctl get-property xyz.openbmc_project.State.BMC.Redundancy.Sibling \
  /xyz/openbmc_project/state/bmc1 \
  xyz.openbmc_project.State.BMC.Redundancy.Sibling FailoverImminent
b false
```

In cfamstool output:
```
 $ ./cfamstool -d | grep -e 'Local BMC' -e 'Sibling BMC' -e Imminent
Local BMC CFAM-S scratchpad fields
Failover Imminent          false

Sibling BMC CFAM-S scratchpad fields
Failover Imminent          false
```

Change-Id: I2c885841aa55a70ec8f6cc8bc84a2b640993302e