### PR TITLE
mpipl: Fix pdbg target init failure handling

### DIFF
--- a/procedures/phal/enter_mpreboot.cpp
+++ b/procedures/phal/enter_mpreboot.cpp
@@ -140,7 +140,16 @@ void enterMpReboot()
     struct pdbg_target* target;
     std::vector<pid_t> pidList;
     bool failed = false;
-    pdbg_targets_init(NULL);
+
+    pdbg_set_loglevel(PDBG_NOTICE);
+
+    if (!pdbg_targets_init(NULL))
+    {
+        log<level::ERR>("pdbg target init failed");
+        openpower::pel::createPEL("org.open_power.PHAL.Error.MPReboot");
+        std::exit(EXIT_FAILURE);
+    }
+
     ATTR_HWAS_STATE_Type hwasState;
 
     log<level::INFO>("Starting memory preserving reboot");
@@ -152,6 +161,9 @@ void enterMpReboot()
         }
         if (!hwasState.functional)
         {
+            log<level::INFO>(std::format("proc({}) is not functional",
+                                         pdbg_target_index(target))
+                                 .c_str());
             continue;
         }
 


### PR DESCRIPTION
Currently in the enter mpipl path, pdbg target init can fail and the failure status is not being captured to log any error.

This might cause unexpected failures and problems when attempting to read and use the system device tree.

Fix:
Do not allow MPIPL to proceed if pdbg target init fails. Also add additional traces to capture non-functional procs.