### PR TITLE
Execute isteps as a service

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -148,6 +148,22 @@ if build_phal
         'service_files/phal-export-devtree@.service',
         'service_files/phal-create-boottime-guard-indicator.service',
         'service_files/op-clock-data-logger@.service',
+        'istep_services/istep-alignment_check@.service',
+        'istep_services/istep-asset_protection@.service',
+        'istep_services/istep-disableattns@.service',
+        'istep_services/istep-edramrepair@.service',
+        'istep_services/istep-hb_config_update@.service',
+        'istep_services/istep-poweron@.service',
+        'istep_services/istep-proc_attn_listen@.service',
+        'istep_services/istep-proc_clock_test@.service',
+        'istep_services/istep-proc_prep_ipl@.service',
+        'istep_services/istep-proc_select_boot_prom@.service',
+        'istep_services/istep-sbe_config_update@.service',
+        'istep_services/istep-sbe_start@.service',
+        'istep_services/istep-set_ref_clock@.service',
+        'istep_services/istep-startipl@.service',
+        'istep_services/istep-startprd@.service',
+        'istep_services/istep-updatehwmodel@.service',
     ]
     unit_subs.set('ENABLE_PHAL_TRUE', '')
 endif

--- a/service_files/istep_services/istep-alignment_check@.service
+++ b/service_files/istep_services/istep-alignment_check@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep alignment_check for host %i
+After=istep-updatehwmodel@%i.service
+Requires=istep-updatehwmodel@%i.service
+ConditionPathExists=!/run/openbmc/host@%i-on
+Conflicts=obmc-host-stop@%i.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep alignment_check
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-asset_protection@.service
+++ b/service_files/istep_services/istep-asset_protection@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep asset_protection for host %i
+After=istep-edramrepair@%i.service
+Requires=istep-edramrepair@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep asset_protection
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-disableattns@.service
+++ b/service_files/istep_services/istep-disableattns@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep disableattns for host %i
+After=istep-startipl@%i.service
+Requires=istep-startipl@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep disableattns
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-edramrepair@.service
+++ b/service_files/istep_services/istep-edramrepair@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep edramrepair for host %i
+After=istep-proc_prep_ipl@%i.service
+Requires=istep-proc_prep_ipl@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep edramrepair
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-hb_config_update@.service
+++ b/service_files/istep_services/istep-hb_config_update@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep hb_config_update for host %i
+After=istep-proc_select_boot_prom@%i.service
+Requires=istep-proc_select_boot_prom@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep hb_config_update
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-poweron@.service
+++ b/service_files/istep_services/istep-poweron@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=istep poweron for host %i
+Wants=obmc-host-start-pre@%i.target
+After=obmc-host-start-pre@%i.target
+Wants=obmc-host-starting@%i.target
+Before=obmc-host-starting@%i.target
+Before=obmc-host-started@%i.target
+Wants=obmc-power-on@%i.target
+After=obmc-power-on@%i.target
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+ConditionPathExists=!/run/openbmc/mpreboot@%i
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep poweron
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-proc_attn_listen@.service
+++ b/service_files/istep_services/istep-proc_attn_listen@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep proc_attn_listen for host %i
+After=istep-startprd@%i.service
+Requires=istep-startprd@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep proc_attn_listen
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-proc_clock_test@.service
+++ b/service_files/istep_services/istep-proc_clock_test@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep proc_clock_test for host %i
+After=istep-set_ref_clock@%i.service
+Requires=istep-set_ref_clock@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep proc_clock_test
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-proc_prep_ipl@.service
+++ b/service_files/istep_services/istep-proc_prep_ipl@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep proc_prep_ipl for host %i
+After=istep-proc_clock_test@%i.service
+Requires=istep-proc_clock_test@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep proc_prep_ipl
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-proc_select_boot_prom@.service
+++ b/service_files/istep_services/istep-proc_select_boot_prom@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep proc_select_boot_prom for host %i
+After=istep-asset_protection@%i.service
+Requires=istep-asset_protection@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep proc_select_boot_prom
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-sbe_config_update@.service
+++ b/service_files/istep_services/istep-sbe_config_update@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep sbe_config_update for host %i
+After=istep-hb_config_update@%i.service
+Requires=istep-hb_config_update@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep sbe_config_update
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-sbe_start@.service
+++ b/service_files/istep_services/istep-sbe_start@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep sbe_start for host %i
+After=istep-sbe_config_update@%i.service
+Requires=istep-sbe_config_update@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep sbe_start
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-set_ref_clock@.service
+++ b/service_files/istep_services/istep-set_ref_clock@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep set_ref_clock for host %i
+After=istep-alignment_check@%i.service
+Requires=istep-alignment_check@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep set_ref_clock
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-startipl@.service
+++ b/service_files/istep_services/istep-startipl@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep startipl for host %i
+After=istep-poweron@%i.service
+Requires=istep-poweron@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep startipl
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-startprd@.service
+++ b/service_files/istep_services/istep-startprd@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep startprd for host %i
+After=istep-sbe_start@%i.service
+Requires=istep-sbe_start@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep startprd
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target

--- a/service_files/istep_services/istep-updatehwmodel@.service
+++ b/service_files/istep_services/istep-updatehwmodel@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=istep updatehwmodel for host %i
+After=istep-disableattns@%i.service
+Requires=istep-disableattns@%i.service
+Conflicts=obmc-host-stop@%i.target
+ConditionPathExists=!/run/openbmc/host@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/istep updatehwmodel
+RemainAfterExit=yes
+
+[Install]
+RequiredBy=obmc-host-startmin@%i.target


### PR DESCRIPTION
This is an experimental setup to run each istep separately as a service to validate the time taken or other complexities if each step is put into its own service file. The step is using ecmd instead of directly calling the start host application.