### PR TITLE
CFAM: Wait for local CFAM to show up in sysfs

### DIFF
--- a/rbmc-cfam-daemon/src/application.hpp
+++ b/rbmc-cfam-daemon/src/application.hpp
@@ -29,6 +29,14 @@ class Application
         ctx.spawn(run());
     }
 
+    /**
+     * @brief Wait for the local CFAM to become accessible
+     */
+    inline void waitForLocalCFAM()
+    {
+        localBMC.waitForCFAM();
+    }
+
   private:
     /**
      * @brief Starts the CFAM-S read loop.

--- a/rbmc-cfam-daemon/src/cfam_access.cpp
+++ b/rbmc-cfam-daemon/src/cfam_access.cpp
@@ -16,9 +16,9 @@ bool CFAMAccess::exists()
 {
     if (devicePath.empty())
     {
-        findDevicePath();
+        devicePath = findDevicePath();
     }
-    return !devicePath.empty();
+    return !devicePath.empty() && std::filesystem::exists(devicePath);
 }
 
 fs::path CFAMAccess::findDevicePath() const

--- a/rbmc-cfam-daemon/src/cfam_main.cpp
+++ b/rbmc-cfam-daemon/src/cfam_main.cpp
@@ -11,6 +11,9 @@ int main()
 
     Application app{ctx, std::move(driver)};
 
+    // Wait for the local CFAM before claiming the D-Bus name.
+    app.waitForLocalCFAM();
+
     ctx.spawn([](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
         ctx.request_name(SiblingInterface::interface);
         co_return;

--- a/rbmc-cfam-daemon/src/local_bmc.cpp
+++ b/rbmc-cfam-daemon/src/local_bmc.cpp
@@ -32,6 +32,34 @@ sdbusplus::async::task<> LocalBMC::start()
     co_return;
 }
 
+void LocalBMC::waitForCFAM()
+{
+    constexpr int timeout = 25;
+    int seconds = 0;
+
+    while (!cfam.isReady() && (seconds < timeout))
+    {
+        seconds++;
+        if (seconds == 1)
+        {
+            lg2::info("Waiting for local CFAM to be ready");
+        }
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    if (!cfam.isReady())
+    {
+        // TODO: Create an error log calling out this card.
+        lg2::error("Local CFAM is not accessible");
+        throw std::runtime_error("Local CFAM is not accessible");
+    }
+    else if (seconds != 0)
+    {
+        lg2::info("Done waiting for local CFAM to become ready");
+    }
+}
+
 sdbusplus::async::task<> LocalBMC::watchHeartBeat()
 {
     using namespace sdbusplus::bus::match;

--- a/rbmc-cfam-daemon/src/local_bmc.hpp
+++ b/rbmc-cfam-daemon/src/local_bmc.hpp
@@ -51,6 +51,15 @@ class LocalBMC
      */
     void setSiblingCommsOK(bool ok);
 
+    /**
+     * @brief Waits up to 60 seconds for the local CFAM-S device to show
+     *        up in /dev.
+     *
+     * If it never does, it creates an error log and will throw and
+     * exception to crash the daemon and restart it for a retry.
+     */
+    void waitForCFAM();
+
   private:
     using Role =
         sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;

--- a/service_files/xyz.openbmc_project.State.BMC.Redundancy.Sibling.service.in
+++ b/service_files/xyz.openbmc_project.State.BMC.Redundancy.Sibling.service.in
@@ -2,6 +2,8 @@
 Description=Redundant BMC Sibling service
 Wants=xyz.openbmc_project.State.BMC.service
 After=xyz.openbmc_project.State.BMC.service
+StartLimitIntervalSec=60
+StartLimitBurst=2
 
 [Service]
 ExecStart=/usr/libexec/openpower-proc-control/rbmc-cfamd


### PR DESCRIPTION
There is a race condition where the local CFAM-S FSI device path hasn't
been created by the time rbmc-cfamd starts.  That would lead to the
application crashing and restarting, where then it usually works.

It's possible in the future the race could be fixed with a proper
service dependency on the FSI scan, but right now that is buried in the
'set SPI mux' service.  That service won't be valid on real PST
redundant BMC hardware because the SPI mux won't be accessible until the
local bus is taken.

For now, handle this better by waiting for the device path of the local
CFAM to show up before even claiming the D-Bus name.  This will hold off
the RBMC manager app to wait until after the CFAM shows up, for at least
the first attempt.

It will wait 25 seconds max, after which it will create an error log
(eventually) and crash so it can restart and try again.  The service
start limit burst settings were modified to allow it to try one more
time before the service will be considered failed.

If it were to never show up at all:
1. The RBMC app would select the passive role because it sees the
   sibling daemon unit isn't active.
2. The system would go to the Quiesced state because this app will
   be (eventually) in the critical services list.

Tested:

Can see it waiting:
```
Jul 14 18:33:02 rbmc-cfamd[841]: Waiting for local CFAM to be ready
Jul 14 18:33:03 rbmc-cfamd[841]: Done waiting for local CFAM to become ready
```

And when it fails repeatedly:
```
rbmc-cfamd[1141]: terminate called after throwing an instance of 'std::runtime_error'
rbmc-cfamd[1141]:   what():  Local CFAM is not accessible
rbmc-cfamd[1141]: Local CFAM is not accessible
xyz.openbmc_project.State.BMC.Redundancy.Sibling.service: Scheduled restart job, restart counter is at 2.
xyz.openbmc_project.State.BMC.Redundancy.Sibling.service: Start request repeated too quickly.
xyz.openbmc_project.State.BMC.Redundancy.Sibling.service: Failed with result 'core-dump'.
systemd[1]: Failed to start Redundant BMC Sibling service.
```