### PR TITLE
CFAM: Support FailoverInProgress field in CFAM

### DIFF
--- a/rbmc-cfam-daemon/README.md
+++ b/rbmc-cfam-daemon/README.md
@@ -19,22 +19,23 @@ The `rbmc-cfam-daemon` meson option will enable building this code.
 
 ## CFAM-S ScratchPad Register Layout
 
-| Field             | Register | Start Bit | Length |
-| ----------------- | -------- | --------- | ------ |
-| API Version       | 1        | 0         | 8      |
-| BMC Position      | 1        | 8         | 1      |
-| Role              | 1        | 9         | 2      |
-| Red Enabled       | 1        | 11        | 1      |
-| Failovers Allowed | 1        | 12        | 1      |
-| Provisioned       | 1        | 13        | 1      |
-| BMC State         | 1        | 14        | 3      |
-| Sibling Comms OK  | 1        | 17        | 1      |
-| Failover Imminent | 1        | 18        | 1      |
-| Reserved          | 1        | 19        | 5      |
-| Heartbeat         | 1        | 24        | 8      |
-| FW Version        | 2        | 0         | 32     |
-| Reserved          | 3        | 0         | 32     |
-| Reserved          | 4        | 0         | 32     |
+| Field                | Register | Start Bit | Length |
+| -------------------- | -------- | --------- | ------ |
+| API Version          | 1        | 0         | 8      |
+| BMC Position         | 1        | 8         | 1      |
+| Role                 | 1        | 9         | 2      |
+| Red Enabled          | 1        | 11        | 1      |
+| Failovers Allowed    | 1        | 12        | 1      |
+| Provisioned          | 1        | 13        | 1      |
+| BMC State            | 1        | 14        | 3      |
+| Sibling Comms OK     | 1        | 17        | 1      |
+| Failover Imminent    | 1        | 18        | 1      |
+| Failover In Progress | 1        | 19        | 1      |
+| Reserved             | 1        | 20        | 4      |
+| Heartbeat            | 1        | 24        | 8      |
+| FW Version           | 2        | 0         | 32     |
+| Reserved             | 3        | 0         | 32     |
+| Reserved             | 4        | 0         | 32     |
 
 ### Field Definitions
 
@@ -62,6 +63,8 @@ property from the BMC state daemon.
 **Failover Imminent**: If the sibling will start a failover soon. Only the
 passive BMC will set this, soon before it starts a failover to become active.
 
+**Failover in Progress**: If a failover is in progress.
+
 **Heartbeat**: This field is incremented by one every time the CFAM application
 receives the Heartbeat signal from the RBMC state manager application. This can
 be used by the sibling to know the management daemon is alive.
@@ -85,6 +88,7 @@ Provisioned                true
 BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
 Sibling Communication OK   true
 Failover Imminent          false
+Failover In Progress       false
 Heartbeat                  0x25
 FW Version                 0x1c9c4045
 
@@ -98,6 +102,7 @@ Provisioned                true
 BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
 Sibling Communication OK   true
 Failover Imminent          false
+Failover In Progress       false
 Heartbeat                  0x24
 FW Version                 0x1c9c4045
 ```

--- a/rbmc-cfam-daemon/src/bmc_cfam.hpp
+++ b/rbmc-cfam-daemon/src/bmc_cfam.hpp
@@ -35,6 +35,7 @@ class BMCCFAM
         bmcState,
         siblingCommsOK,
         failoverImminent,
+        failoverInProgress,
         heartbeat,
         fwVersion
     };
@@ -56,6 +57,8 @@ class BMCCFAM
          {cfam::ScratchPadReg::one, 17, 1, "Sibling Communication OK"}},
         {Field::failoverImminent,
          {cfam::ScratchPadReg::one, 18, 1, "Failover Imminent"}},
+        {Field::failoverInProgress,
+         {cfam::ScratchPadReg::one, 19, 1, "Failover In Progress"}},
         {Field::heartbeat, {cfam::ScratchPadReg::one, 24, 8, "Heartbeat"}},
         {Field::fwVersion, {cfam::ScratchPadReg::two, 0, 32, "FW Version"}}};
 

--- a/rbmc-cfam-daemon/src/cfams_tool.cpp
+++ b/rbmc-cfam-daemon/src/cfams_tool.cpp
@@ -30,6 +30,7 @@ std::string formatValue(BMCCFAM::Field field, uint32_t value)
         case provisioned:
         case siblingCommsOK:
         case failoverImminent:
+        case failoverInProgress:
             result = std::format("{}", value ? "true" : "false");
             break;
         case role:

--- a/rbmc-cfam-daemon/src/local_bmc.cpp
+++ b/rbmc-cfam-daemon/src/local_bmc.cpp
@@ -23,7 +23,8 @@ sdbusplus::async::task<> LocalBMC::start()
         [this](auto role) { roleChanged(role); },
         [this](auto enabled) { redEnabledChanged(enabled); },
         [this](auto allowed) { failoversAllowedChanged(allowed); },
-        [this](auto imminent) { failoverImminentChanged(imminent); });
+        [this](auto imminent) { failoverImminentChanged(imminent); },
+        [this](auto inProgress) { failoverInProgressChanged(inProgress); });
 
     co_await writeRedundancyProps();
     co_await writeBMCState();
@@ -158,21 +159,30 @@ void LocalBMC::failoverImminentChanged(bool imminent)
     cfam.writeFailoverImminent(imminent);
 }
 
+void LocalBMC::failoverInProgressChanged(bool inProgress)
+{
+    lg2::info("Local Failover In Progress changed to {INPROGRESS}",
+              "INPROGRESS", inProgress);
+    cfam.writeFailoverInProgress(inProgress);
+}
+
 sdbusplus::async::task<> LocalBMC::writeRedundancyProps()
 {
     try
     {
-        auto [role, enabled, allowed,
-              imminent] = co_await services->getRedundancyProps();
-        lg2::info(
-            "Initial values of local role, redEnabled, fo allowed, fo imminent: {ROLE} {ENABLED} {ALLOWED} {IMMINENT}",
-            "ROLE", role, "ENABLED", enabled, "ALLOWED", allowed, "IMMINENT",
-            imminent);
+        auto props = co_await services->getRedundancyProps();
+        lg2::debug(
+            "Initial values of local role, redEnabled, fo allowed, fo imminent, fo in "
+            "progress: {ROLE} {ENABLED} {ALLOWED} {IMMINENT} {IN_PROGRESS}",
+            "ROLE", props.role, "ENABLED", props.redundancy_enabled, "ALLOWED",
+            props.failovers_allowed, "IMMINENT", props.failover_imminent,
+            "IN_PROGRESS", props.failover_in_progress);
 
-        cfam.writeRole(role);
-        cfam.writeRedundancyEnabled(enabled);
-        cfam.writeFailoversAllowed(allowed);
-        cfam.writeFailoverImminent(imminent);
+        cfam.writeRole(props.role);
+        cfam.writeRedundancyEnabled(props.redundancy_enabled);
+        cfam.writeFailoversAllowed(props.failovers_allowed);
+        cfam.writeFailoverImminent(props.failover_imminent);
+        cfam.writeFailoverInProgress(props.failover_in_progress);
     }
     catch (const sdbusplus::exception_t& e)
     {

--- a/rbmc-cfam-daemon/src/local_bmc.hpp
+++ b/rbmc-cfam-daemon/src/local_bmc.hpp
@@ -159,6 +159,17 @@ class LocalBMC
     void failoverImminentChanged(bool imminent);
 
     /**
+     * @brief Callback function for when the failover
+     * in progress D-Bus property changes.
+     *
+     * Writes the new value into the CFAM in the
+     * FailoverInProgress field.
+     *
+     * @param[in] inProgress - the value to write
+     */
+    void failoverInProgressChanged(bool inProgress);
+
+    /**
      * @brief The context object
      */
     sdbusplus::async::context& ctx;

--- a/rbmc-cfam-daemon/src/local_cfam.cpp
+++ b/rbmc-cfam-daemon/src/local_cfam.cpp
@@ -137,6 +137,18 @@ void LocalCFAM::writeFailoverImminent(bool imminent)
     }
 }
 
+void LocalCFAM::writeFailoverInProgress(bool inProgress)
+{
+    auto rc = writeField(Field::failoverInProgress, inProgress);
+    if (rc != 0)
+    {
+        lg2::error(
+            "Failed writing Failover In Progress field {IN_PROGRESS} in local CFAM",
+            "IN_PROGRESS", inProgress);
+        throw std::system_error(rc, std::generic_category());
+    }
+}
+
 std::expected<uint32_t, int> LocalCFAM::readField(Field field)
 {
     auto data = cfamAccess.readScratchReg(cfamFields.at(field).reg);

--- a/rbmc-cfam-daemon/src/local_cfam.hpp
+++ b/rbmc-cfam-daemon/src/local_cfam.hpp
@@ -128,6 +128,13 @@ class LocalCFAM : public BMCCFAM
     void writeFailoverImminent(bool imminent);
 
     /**
+     * @brief Writes the failover in progress field into the CFAM
+     *
+     * @param[in] inProgress - If a failover is inProgress
+     */
+    void writeFailoverInProgress(bool inProgress);
+
+    /**
      * @brief Increments the heartbeat field in the CFAM
      */
     void incHeartbeat();

--- a/rbmc-cfam-daemon/src/services.cpp
+++ b/rbmc-cfam-daemon/src/services.cpp
@@ -42,12 +42,14 @@ Services::Services(
     sdbusplus::async::context& ctx, BMCStateCallback&& stateCallback,
     RoleCallback&& roleCallback, RedEnabledCallback&& redEnabledCallback,
     FailoversAllowedCallback&& failoversAllowedCallback,
-    FailoverImminentCallback&& failoverImminentCallback) :
+    FailoverImminentCallback&& failoverImminentCallback,
+    FailoverInProgressCallback&& failoverInProgressCallback) :
     ctx(ctx), bmcStateCallback(std::move(stateCallback)),
     roleCallback(std::move(roleCallback)),
     redEnabledCallback(std::move(redEnabledCallback)),
     failoversAllowedCallback(std::move(failoversAllowedCallback)),
     failoverImminentCallback(std::move(failoverImminentCallback)),
+    failoverInProgressCallback(std::move(failoverInProgressCallback)),
     localBMCPath(
         sdbusplus::message::object_path{RedNSPath::value} / RedNSPath::bmc)
 {
@@ -148,7 +150,7 @@ sdbusplus::async::task<Services::BMCState> Services::getBMCState()
         .current_bmc_state();
 }
 
-sdbusplus::async::task<std::tuple<Services::Role, bool, bool, bool>>
+sdbusplus::async::task<Services::RedundancyProperties>
     Services::getRedundancyProps()
 {
     auto service = co_await util::getService(ctx, localBMCPath,
@@ -157,13 +159,10 @@ sdbusplus::async::task<std::tuple<Services::Role, bool, bool, bool>>
     using Redundancy =
         sdbusplus::client::xyz::openbmc_project::state::bmc::Redundancy<>;
 
-    auto props = co_await Redundancy(ctx)
-                     .service(service)
-                     .path(localBMCPath)
-                     .properties();
-
-    co_return std::make_tuple(props.role, props.redundancy_enabled,
-                              props.failovers_allowed, props.failover_imminent);
+    co_return co_await Redundancy(ctx)
+        .service(service)
+        .path(localBMCPath)
+        .properties();
 }
 
 sdbusplus::async::task<> Services::watchBMCStateProp()
@@ -223,6 +222,12 @@ sdbusplus::async::task<> Services::watchRedundancyProps()
         {
             failoverImminentCallback(std::get<bool>(it->second));
         }
+
+        it = propertyMap.find("FailoverInProgress");
+        if (it != propertyMap.end())
+        {
+            failoverInProgressCallback(std::get<bool>(it->second));
+        }
     }
 }
 
@@ -281,6 +286,12 @@ sdbusplus::async::task<> Services::watchBMCInterfaceAdded()
             if (propIt != props.end())
             {
                 failoverImminentCallback(std::get<bool>(propIt->second));
+            }
+
+            propIt = props.find("FailoverInProgress");
+            if (propIt != props.end())
+            {
+                failoverInProgressCallback(std::get<bool>(propIt->second));
             }
         }
     }

--- a/rbmc-cfam-daemon/src/services.hpp
+++ b/rbmc-cfam-daemon/src/services.hpp
@@ -19,12 +19,15 @@ class Services
         sdbusplus::common::xyz::openbmc_project::state::bmc::Redundancy::Role;
     using BMCState =
         sdbusplus::common::xyz::openbmc_project::state::BMC::BMCState;
+    using RedundancyProperties = sdbusplus::common::xyz::openbmc_project::
+        state::bmc::Redundancy::properties_t;
 
     using BMCStateCallback = std::function<void(BMCState)>;
     using RoleCallback = std::function<void(Role)>;
     using RedEnabledCallback = std::function<void(bool)>;
     using FailoversAllowedCallback = std::function<void(bool)>;
     using FailoverImminentCallback = std::function<void(bool)>;
+    using FailoverInProgressCallback = std::function<void(bool)>;
 
     Services() = delete;
     ~Services() = default;
@@ -46,13 +49,16 @@ class Services
      * @param[in] failoversAllowedCallback - Function to run when this prop
      *                                      changes
      * @param[in] failoverImminentCallback - Function to run when this
+     *                                       prop changes
+     * @param[in] failoverInProgressCallback - Function to run when this
      *                                         prop changes
      */
     Services(sdbusplus::async::context& ctx, BMCStateCallback&& stateCallback,
              RoleCallback&& roleCallback,
              RedEnabledCallback&& redEnabledCallback,
              FailoversAllowedCallback&& failoversAllowedCallback,
-             FailoverImminentCallback&& failoverImminentCallback);
+             FailoverImminentCallback&& failoverImminentCallback,
+             FailoverInProgressCallback&& failoverInProgressCallback);
 
     /**
      * @brief Reads the CurrentBMCState property
@@ -62,13 +68,11 @@ class Services
     sdbusplus::async::task<BMCState> getBMCState();
 
     /**
-     * @brief Reads the role and redundancyEnabled properties
+     * @brief Reads all properties from the Redundancy interface
      *
-     * @return - A tuple of role, redundancyEnabled, FailoversAllowed
-     *           FailoverImminent
+     * @return - The properties_t struct of all properties
      */
-    sdbusplus::async::task<std::tuple<Services::Role, bool, bool, bool>>
-        getRedundancyProps();
+    sdbusplus::async::task<RedundancyProperties> getRedundancyProps();
 
     /**
      * @brief Reads the VERSION_ID field out of the version file.
@@ -148,6 +152,11 @@ class Services
      * @brief The callback function for FailoverImminent
      */
     FailoverImminentCallback failoverImminentCallback;
+
+    /**
+     * @brief The callback function for FailoverInProgress
+     */
+    FailoverInProgressCallback failoverInProgressCallback;
 
     /**
      * @brief Object path for this BMC's redundancy and state interfaces.

--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -72,6 +72,8 @@ void SiblingBMC::read()
     siblingObject->failoversAllowed(cfam.getFailoversAllowed(), createdObject);
     siblingObject->currentBMCState(cfam.getBMCState(), createdObject);
     siblingObject->failoverImminent(cfam.getFailoverImminent(), createdObject);
+    siblingObject->failoverInProgress(cfam.getFailoverInProgress(),
+                                      createdObject);
 
     auto version = std::format("{:08X}", cfam.getFWVersion());
     siblingObject->version(version, createdObject);

--- a/rbmc-cfam-daemon/src/sibling_cfam.cpp
+++ b/rbmc-cfam-daemon/src/sibling_cfam.cpp
@@ -42,6 +42,9 @@ void SiblingCFAM::readAll()
 
     failoverImminent =
         cfam::getFieldValue(*regs, cfamFields.at(Field::failoverImminent));
+
+    failoverInProgress =
+        cfam::getFieldValue(*regs, cfamFields.at(Field::failoverInProgress));
 }
 
 uint8_t SiblingCFAM::getApiVersion() const
@@ -132,6 +135,15 @@ bool SiblingCFAM::getFailoverImminent() const
         throw std::runtime_error{"CFAM fields not available"};
     }
     return failoverImminent;
+}
+
+bool SiblingCFAM::getFailoverInProgress() const
+{
+    if (error)
+    {
+        throw std::runtime_error{"CFAM fields not available"};
+    }
+    return failoverInProgress;
 }
 
 uint32_t SiblingCFAM::getHeartbeat() const

--- a/rbmc-cfam-daemon/src/sibling_cfam.hpp
+++ b/rbmc-cfam-daemon/src/sibling_cfam.hpp
@@ -113,6 +113,13 @@ class SiblingCFAM : public BMCCFAM
     bool getFailoverImminent() const;
 
     /**
+     * @brief Returns the failover in progress field
+     *
+     * Will throw if there is a hardware error
+     */
+    bool getFailoverInProgress() const;
+
+    /**
      * @brief Returns the heartbeat field
      *
      * Will throw if there is a hardware error
@@ -167,6 +174,9 @@ class SiblingCFAM : public BMCCFAM
 
     /** @brief Latest failover imminent value */
     bool failoverImminent{};
+
+    /** @brief Latest failover in progress value */
+    bool failoverInProgress{};
 
     /** @brief The set of scratchpad regs that contain field */
     std::set<cfam::ScratchPadReg> usedRegs;

--- a/rbmc-cfam-daemon/test/sibling_cfam_test.cpp
+++ b/rbmc-cfam-daemon/test/sibling_cfam_test.cpp
@@ -18,7 +18,7 @@ TEST_F(SiblingCFAMTest, TestReads)
     SiblingCFAM sibling{1, driver};
 
     EXPECT_CALL(driver, read(link1Device, 0))
-        .WillOnce(Return(Expected(0x01DDEFFF)));
+        .WillOnce(Return(Expected(0x01DDFFFF)));
     EXPECT_CALL(driver, read(link1Device, 1))
         .WillOnce(Return(Expected(0x12345678)));
 
@@ -41,6 +41,7 @@ TEST_F(SiblingCFAMTest, TestReads)
     EXPECT_EQ(sibling.getHeartbeat(), 0xFF);
     EXPECT_EQ(sibling.getFWVersion(), 0x12345678);
     EXPECT_EQ(sibling.getFailoverImminent(), true);
+    EXPECT_EQ(sibling.getFailoverInProgress(), true);
 }
 
 TEST_F(SiblingCFAMTest, TestReadFail)
@@ -67,4 +68,5 @@ TEST_F(SiblingCFAMTest, TestReadFail)
     EXPECT_THROW(sibling.getSiblingCommsOK(), std::runtime_error);
     EXPECT_THROW(sibling.getHeartbeat(), std::runtime_error);
     EXPECT_THROW(sibling.getFailoverImminent(), std::runtime_error);
+    EXPECT_THROW(sibling.getFailoverInProgress(), std::runtime_error);
 }


### PR DESCRIPTION
This new field is set by the RBMC manager code when it is in the middle of driving a failover.

This is being put in the CFAM so that the sibling BMC, the previously active BMC that would have been reset as part of the failover, can use it during role determination to choose the passive role when it comes back.

This is necessary because while normally the BMC would just choose the opposite role of the other BMC, if that other BMC that was driving the failover was rebooted along the way, then it wouldn't be up and running at that time and both BMCs may think they were previously active and try to become active.

Tested:
Written into the local CFAM correctly:
```
Local BMC CFAM-S scratchpad fields
API Version                0x1
BMC Position               0x1
Role                       xyz.openbmc_project.State.BMC.Redundancy.Role.Active
Redundancy Enabled         true
Failovers Allowed          false
Provisioned                true
BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
Sibling Communication OK   true
Failover Imminent          false
Failover In Progress       true <---------------------------------
Heartbeat                  0x1a
FW Version                 0x7d719923
```

And when old passive comes back from the failover reset, it can see it:
```
$ busctl get-property xyz.openbmc_project.State.BMC.Redundancy.Sibling \
  /xyz/openbmc_project/state/bmc1 \
  xyz.openbmc_project.State.BMC.Redundancy \
  FailoverInProgress
b true
```

Change-Id: I74b43d1df92b0d6b02650165292e6cd778006981