### PR TITLE
CFAM: Remove D-Bus ifaces when no heartbeat

### DIFF
--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -48,6 +48,25 @@ void SiblingBMC::read()
         return;
     }
 
+    // Must detect a heartbeat change to consider it alive, so it won't
+    // be alive until at least the second time though.
+    auto heartbeat = cfam.getHeartbeat();
+    auto alive = lastHeartbeat.has_value() &&
+                 (heartbeat != lastHeartbeat.value());
+    lastHeartbeat = heartbeat;
+
+    if (!alive)
+    {
+        if (siblingObject)
+        {
+            lg2::info("Removing sibling object because heartbeat stopped");
+            siblingObject.reset();
+
+            siblingInterface.reset();
+        }
+        return;
+    }
+
     if (!siblingObject)
     {
         lg2::info("Creating Sibling D-Bus interfaces");
@@ -77,14 +96,7 @@ void SiblingBMC::read()
 
     auto version = std::format("{:08X}", cfam.getFWVersion());
     siblingObject->version(version, createdObject);
-
-    // Must detect a heartbeat change to consider it active, so it won't
-    // be active until at least the second time though.
-    auto heartbeat = cfam.getHeartbeat();
-    auto alive = lastHeartbeat.has_value() &&
-                 (heartbeat != lastHeartbeat.value());
     siblingObject->active(alive, createdObject);
-    lastHeartbeat = heartbeat;
 
     if (createdObject)
     {


### PR DESCRIPTION
Removing the D-Bus interfaces that contain the sibling BMC data from D-Bus when there is no heartbeat makes it so clients can depend on the presence of the interfaces meaning that the fields are valid without having to read the heartbeat active property first.

The rbmc-state-manager already supports this as it already handles the loss of the interfaces to mean the sibling BMC isn't alive.

A future commit will also remove the heartbeat interface completely after the rbmc-state-manager stops using it.

Tested:

Interfaces are removed when heartbeat stops:
```
rbmc-cfamd[827]: Removing sibling object because heartbeat stopped
```

And available again when it re-starts:
```
rbmc-cfamd[827]: Creating Sibling D-Bus interfaces
```

Change-Id: I02189e480df13eb11532ec08069423445148999b