### PR TITLE
Retry on CFAM access failures and put CFAM presence on D-Bus

### DIFF
--- a/rbmc-cfam-daemon/src/application.cpp
+++ b/rbmc-cfam-daemon/src/application.cpp
@@ -10,12 +10,10 @@ sdbusplus::async::task<> Application::run()
 
     while (!ctx.stop_requested())
     {
-        // Eventually what's off of link 1 may not be a BMC and we'll need
-        // a way to know that.  For now, assume it's the sibling BMC's CFAM
-        // if it's there.
         if (!siblingBMC && link1.exists())
         {
-            siblingBMC = std::make_unique<SiblingBMC>(ctx, 1, *driver.get());
+            siblingBMC = std::make_unique<SiblingBMC>(ctx, 1, *driver.get(),
+                                                      availInterface);
         }
 
         if (siblingBMC)

--- a/rbmc-cfam-daemon/src/application.cpp
+++ b/rbmc-cfam-daemon/src/application.cpp
@@ -20,7 +20,7 @@ sdbusplus::async::task<> Application::run()
 
         if (siblingBMC)
         {
-            siblingBMC->read();
+            co_await siblingBMC->read();
             localBMC.setSiblingCommsOK(siblingBMC->ok());
         }
 

--- a/rbmc-cfam-daemon/src/application.hpp
+++ b/rbmc-cfam-daemon/src/application.hpp
@@ -24,7 +24,10 @@ class Application
      * @param fs - The Driver object
      */
     Application(sdbusplus::async::context& ctx, std::unique_ptr<Driver> d) :
-        ctx(ctx), driver(std::move(d)), localBMC(ctx, *driver.get())
+        ctx(ctx), driver(std::move(d)), localBMC(ctx, *driver.get()),
+        availInterface(
+            ctx.get_bus(), SiblingBMC::getObjectPath().c_str(),
+            {{"Available", AvailInterface::PropertiesVariant{false}}}, true)
     {
         ctx.spawn(run());
     }
@@ -64,4 +67,12 @@ class Application
      * Only created if sibling is present.
      */
     std::unique_ptr<SiblingBMC> siblingBMC;
+
+    /**
+     * @brief D-Bus The Availability D-Bus interface
+     *
+     * Holds the Available property that indicates if the sibling
+     * BMC's CFAM FSI device is present.
+     */
+    AvailInterface availInterface;
 };

--- a/rbmc-cfam-daemon/src/cfam_access.cpp
+++ b/rbmc-cfam-daemon/src/cfam_access.cpp
@@ -8,9 +8,11 @@
 
 #include <phosphor-logging/lg2.hpp>
 
+#include <thread>
 #include <utility>
 
 namespace fs = std::filesystem;
+constexpr size_t maxAttempts = 10;
 
 bool CFAMAccess::exists()
 {
@@ -53,7 +55,33 @@ fs::path CFAMAccess::findDevicePath() const
 
 std::expected<uint32_t, int> CFAMAccess::readScratchReg(cfam::ScratchPadReg reg)
 {
-    return driver.read(devicePath, std::to_underlying(reg));
+    size_t attempts = 0;
+    std::expected<uint32_t, int> result;
+
+    while (attempts < maxAttempts)
+    {
+        result = driver.read(devicePath, std::to_underlying(reg));
+        if (!result.has_value())
+        {
+            lg2::error(
+                "readScratchReg failed on {PATH} reg {REG} with errno {ERROR}",
+                "PATH", devicePath, "REG", std::to_underlying(reg), "ERROR",
+                result.error());
+            attempts++;
+
+            if (attempts < maxAttempts)
+            {
+                lg2::warning("Retrying read");
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    return result;
 }
 
 CFAMAccess::RegMapExpected CFAMAccess::readScratchRegs(
@@ -79,11 +107,64 @@ CFAMAccess::RegMapExpected CFAMAccess::readScratchRegs(
 
 int CFAMAccess::writeScratchReg(cfam::ScratchPadReg reg, uint32_t data)
 {
-    return driver.write(devicePath, std::to_underlying(reg), data);
+    size_t attempts = 0;
+    int rc = 0;
+
+    while (attempts < maxAttempts)
+    {
+        rc = driver.write(devicePath, std::to_underlying(reg), data);
+
+        if (rc != 0)
+        {
+            lg2::error(
+                "writeScratchReg failed on {PATH} reg {REG} with error {ERROR}",
+                "PATH", devicePath, "REG", std::to_underlying(reg), "ERROR",
+                rc);
+            attempts++;
+
+            if (attempts < maxAttempts)
+            {
+                lg2::warning("Retrying write");
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    return rc;
 }
 
 int CFAMAccess::writeScratchRegWithMask(const cfam::ModifyOp& op)
 {
-    return driver.writeWithMask(devicePath, std::to_underlying(op.reg), op.data,
-                                op.mask);
+    size_t attempts = 0;
+    int rc = 0;
+
+    while (attempts < maxAttempts)
+    {
+        rc = driver.writeWithMask(devicePath, std::to_underlying(op.reg),
+                                  op.data, op.mask);
+        if (rc != 0)
+        {
+            lg2::error(
+                "writeScratchRegWithMask failed on {PATH} reg {REG} with errno {ERROR}",
+                "PATH", devicePath, "REG", std::to_underlying(op.reg), "ERROR",
+                rc);
+            attempts++;
+
+            if (attempts < maxAttempts)
+            {
+                lg2::warning("Retrying writeWithMask");
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    return rc;
 }

--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -3,13 +3,47 @@
 
 #include <phosphor-logging/lg2.hpp>
 
+#include <chrono>
 #include <format>
 
-void SiblingBMC::read()
+sdbusplus::async::task<bool> SiblingBMC::checkCFAMReady()
+{
+    constexpr size_t maxAttempts = 10;
+    size_t attempts = 0;
+
+    while (attempts < maxAttempts)
+    {
+        if (cfam.isReady())
+        {
+            co_return true;
+        }
+
+        attempts++;
+        if (attempts < maxAttempts)
+        {
+            if (ready)
+            {
+                lg2::warning("Sibling BMC CFAM not ready. Retrying");
+            }
+            co_await sdbusplus::async::sleep_for(ctx,
+                                                 std::chrono::milliseconds(50));
+        }
+        else
+        {
+            if (ready)
+            {
+                lg2::error("Giving up");
+            }
+        }
+    }
+    co_return false;
+}
+
+sdbusplus::async::task<> SiblingBMC::read()
 {
     bool createdObject = false;
 
-    if (!cfam.isReady())
+    if (!co_await checkCFAMReady())
     {
         if (ready)
         {
@@ -25,7 +59,7 @@ void SiblingBMC::read()
 
             siblingInterface.reset();
         }
-        return;
+        co_return;
     }
 
     if (!ready)
@@ -45,7 +79,7 @@ void SiblingBMC::read()
 
             siblingInterface.reset();
         }
-        return;
+        co_return;
     }
 
     // Must detect a heartbeat change to consider it alive, so it won't
@@ -64,7 +98,7 @@ void SiblingBMC::read()
 
             siblingInterface.reset();
         }
-        return;
+        co_return;
     }
 
     if (!siblingObject)

--- a/rbmc-cfam-daemon/src/sibling_bmc.cpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.cpp
@@ -59,8 +59,13 @@ sdbusplus::async::task<> SiblingBMC::read()
 
             siblingInterface.reset();
         }
+
+        availInterface.available(false);
+
         co_return;
     }
+
+    availInterface.available(true);
 
     if (!ready)
     {
@@ -105,15 +110,11 @@ sdbusplus::async::task<> SiblingBMC::read()
     {
         lg2::info("Creating Sibling D-Bus interfaces");
 
-        auto objectPath =
-            sdbusplus::message::object_path{RedIntf::namespace_path::value} /
-            RedIntf::namespace_path::sibling_bmc;
-
-        siblingObject =
-            std::make_unique<SiblingObject>(ctx.get_bus(), objectPath.str);
+        siblingObject = std::make_unique<SiblingObject>(
+            ctx.get_bus(), getObjectPath().c_str());
 
         siblingInterface = std::make_unique<SiblingInterface>(
-            ctx.get_bus(), objectPath.str.c_str(),
+            ctx.get_bus(), getObjectPath().c_str(),
             SiblingInterface::action::defer_emit);
 
         createdObject = true;

--- a/rbmc-cfam-daemon/src/sibling_bmc.hpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.hpp
@@ -5,10 +5,14 @@
 
 #include <sdbusplus/async.hpp>
 #include <xyz/openbmc_project/State/BMC/Redundancy/Sibling/server.hpp>
+#include <xyz/openbmc_project/State/Decorator/Availability/server.hpp>
 
 using SiblingIntf =
     sdbusplus::xyz::openbmc_project::State::BMC::Redundancy::server::Sibling;
 using SiblingInterface = sdbusplus::server::object_t<SiblingIntf>;
+
+using AvailInterface =
+    sdbusplus::server::xyz::openbmc_project::state::decorator::Availability;
 
 /**
  * @class SiblingBMC
@@ -37,9 +41,11 @@ class SiblingBMC
      * @param[in] ctx - The async context object
      * @param[in] link - The FSI link for the CFAM
      * @param[in] driver - The driver object
+     * @param[in] availIface - Availability D-Bus iface obj
      */
-    SiblingBMC(sdbusplus::async::context& ctx, size_t link, Driver& driver) :
-        ctx(ctx), cfam(link, driver)
+    SiblingBMC(sdbusplus::async::context& ctx, size_t link, Driver& driver,
+               AvailInterface& availIface) :
+        ctx(ctx), availInterface(availIface), cfam(link, driver)
     {}
 
     /**
@@ -63,6 +69,15 @@ class SiblingBMC
     bool ok()
     {
         return cfam.isReady() && !cfam.hasError();
+    }
+
+    /**
+     * @brief Returns the D-Bus object path for the sibling BMC.
+     */
+    static std::string getObjectPath()
+    {
+        return std::string{RedIntf::namespace_path::value} + '/' +
+               RedIntf::namespace_path::sibling_bmc;
     }
 
   private:
@@ -89,6 +104,14 @@ class SiblingBMC
      * @brief The Sibling D-Bus object
      */
     std::unique_ptr<SiblingObject> siblingObject;
+
+    /**
+     * @brief D-Bus The Availability D-Bus interface
+     *
+     * Holds the Available property that indicates if the sibling
+     * BMC's CFAM FSI device is present.
+     */
+    AvailInterface& availInterface;
 
     /**
      * @brief The last heartbeat value read from the CFAM.

--- a/rbmc-cfam-daemon/src/sibling_bmc.hpp
+++ b/rbmc-cfam-daemon/src/sibling_bmc.hpp
@@ -53,7 +53,7 @@ class SiblingBMC
      * 3) If there are errors, remove the interface from D-Bus so nobody
      *    can read stale values.
      */
-    void read();
+    sdbusplus::async::task<> read();
 
     /**
      * @brief Says if it could successfully read the CFAM.
@@ -66,6 +66,15 @@ class SiblingBMC
     }
 
   private:
+    /**
+     * @brief Checks if CFAM is ready to access.
+     *
+     * Will retry a few times if it isn't.
+     *
+     * @return bool - If ready or not
+     */
+    sdbusplus::async::task<bool> checkCFAMReady();
+
     /**
      * @brief The context object
      */

--- a/rbmc-cfam-daemon/test/cfam_access_test.cpp
+++ b/rbmc-cfam-daemon/test/cfam_access_test.cpp
@@ -13,19 +13,50 @@ class CFAMAccessTest : public CFAMSDevice
 // Test CFAMAccess::readScratchReg()
 TEST_F(CFAMAccessTest, ReadTest)
 {
-    MockDriver driver;
-    std::expected<uint32_t, int> expected = 0x12345678;
+    // Passes
+    {
+        MockDriver driver;
 
-    // First read works, next one fails
-    EXPECT_CALL(driver, read(link0Device, 0)).WillOnce(Return(expected));
-    EXPECT_CALL(driver, read(link0Device, 1))
-        .WillOnce(Return(std::unexpected<int>{2}));
+        EXPECT_CALL(driver, read(link0Device, 0)).WillOnce(Return(0x12345678));
 
-    CFAMAccess cfam{0, driver};
+        CFAMAccess cfam{0, driver};
 
-    EXPECT_EQ(cfam.readScratchReg(cfam::ScratchPadReg::one), 0x12345678);
-    EXPECT_EQ(cfam.readScratchReg(cfam::ScratchPadReg::two),
-              std::unexpected<int>{2});
+        EXPECT_EQ(cfam.readScratchReg(cfam::ScratchPadReg::one), 0x12345678);
+    }
+
+    // 9 fails, then last retry works
+    {
+        MockDriver driver;
+
+        EXPECT_CALL(driver, read(link0Device, 1))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(std::unexpected<int>{2}))
+            .WillOnce(Return(0x12345678));
+
+        CFAMAccess cfam{0, driver};
+
+        EXPECT_EQ(cfam.readScratchReg(cfam::ScratchPadReg::two), 0x12345678);
+    }
+
+    // All retries fail
+    {
+        MockDriver driver;
+
+        EXPECT_CALL(driver, read(link0Device, 1))
+            .WillRepeatedly(Return(std::unexpected<int>{2}));
+
+        CFAMAccess cfam{0, driver};
+
+        EXPECT_EQ(cfam.readScratchReg(cfam::ScratchPadReg::two),
+                  std::unexpected(2));
+    }
 }
 
 // Test CFAMAccess::readScratchRegs
@@ -63,7 +94,7 @@ TEST_F(CFAMAccessTest, ReadScratchRegsTest)
         EXPECT_EQ(results, expectedResults);
     }
 
-    // A read fails
+    // One register fails all retries
     {
         MockDriver driver;
         EXPECT_CALL(driver, read(link0Device, 0))
@@ -71,7 +102,7 @@ TEST_F(CFAMAccessTest, ReadScratchRegsTest)
         EXPECT_CALL(driver, read(link0Device, 1))
             .WillOnce(Return(readValues[1]));
         EXPECT_CALL(driver, read(link0Device, 2))
-            .WillOnce(Return(std::unexpected<int>{2}));
+            .WillRepeatedly(Return(std::unexpected<int>{2}));
 
         CFAMAccess cfam{0, driver};
         auto results = cfam.readScratchRegs(regs);
@@ -82,36 +113,107 @@ TEST_F(CFAMAccessTest, ReadScratchRegsTest)
 // Test CFAMAccess::writeScratchReg()
 TEST_F(CFAMAccessTest, WriteTest)
 {
-    MockDriver driver;
+    // Write works
+    {
+        MockDriver driver;
 
-    // First write works, next one fails
-    EXPECT_CALL(driver, write(link0Device, 0, 0x12345678)).WillOnce(Return(0));
-    EXPECT_CALL(driver, write(link0Device, 1, 0)).WillOnce(Return(-1));
+        // First write works
+        EXPECT_CALL(driver, write(link0Device, 0, 0x12345678))
+            .WillOnce(Return(0));
 
-    CFAMAccess cfam{0, driver};
+        CFAMAccess cfam{0, driver};
 
-    EXPECT_EQ(cfam.writeScratchReg(cfam::ScratchPadReg::one, 0x12345678), 0);
-    EXPECT_EQ(cfam.writeScratchReg(cfam::ScratchPadReg::two, 0), -1);
+        EXPECT_EQ(cfam.writeScratchReg(cfam::ScratchPadReg::one, 0x12345678),
+                  0);
+    }
+
+    // 9 fails, last retry works
+    {
+        MockDriver driver;
+
+        EXPECT_CALL(driver, write(link0Device, 0, 0x12345678))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(0));
+
+        CFAMAccess cfam{0, driver};
+
+        EXPECT_EQ(cfam.writeScratchReg(cfam::ScratchPadReg::one, 0x12345678),
+                  0);
+    }
+
+    // All attempts fail
+    {
+        MockDriver driver;
+
+        EXPECT_CALL(driver, write(link0Device, 0, 0x12345678))
+            .WillRepeatedly(Return(1));
+
+        CFAMAccess cfam{0, driver};
+
+        EXPECT_EQ(cfam.writeScratchReg(cfam::ScratchPadReg::one, 0x12345678),
+                  1);
+    }
 }
 
 // Test CFAMAccess::writeScratchRegWithMask()
 TEST_F(CFAMAccessTest, WriteWithMaskTest)
 {
-    MockDriver driver;
+    // Write works
+    {
+        MockDriver driver;
 
-    EXPECT_CALL(driver, writeWithMask(link0Device, 0, 0x00AAAA00, 0x00FFFF00))
-        .WillOnce(Return(0));
+        EXPECT_CALL(driver,
+                    writeWithMask(link0Device, 0, 0x00AAAA00, 0x00FFFF00))
+            .WillOnce(Return(0));
 
-    EXPECT_CALL(driver, writeWithMask(link0Device, 1, 0x00AAAA00, 0x00FFFF00))
-        .WillOnce(Return(-1));
+        CFAMAccess cfam{0, driver};
 
-    CFAMAccess cfam{0, driver};
+        cfam::ModifyOp op{cfam::ScratchPadReg::one, 0x00AAAA00, 0x00FFFF00};
+        EXPECT_EQ(cfam.writeScratchRegWithMask(op), 0);
+    }
 
-    // Good
-    cfam::ModifyOp op{cfam::ScratchPadReg::one, 0x00AAAA00, 0x00FFFF00};
-    EXPECT_EQ(cfam.writeScratchRegWithMask(op), 0);
+    // 9 fails, last retry works
+    {
+        MockDriver driver;
 
-    // Fails
-    op.reg = cfam::ScratchPadReg::two;
-    EXPECT_EQ(cfam.writeScratchRegWithMask(op), -1);
+        EXPECT_CALL(driver,
+                    writeWithMask(link0Device, 0, 0x00AAAA00, 0x00FFFF00))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(-1))
+            .WillOnce(Return(0));
+
+        CFAMAccess cfam{0, driver};
+
+        cfam::ModifyOp op{cfam::ScratchPadReg::one, 0x00AAAA00, 0x00FFFF00};
+        EXPECT_EQ(cfam.writeScratchRegWithMask(op), 0);
+    }
+
+    // All attempts fail
+    {
+        MockDriver driver;
+
+        EXPECT_CALL(driver,
+                    writeWithMask(link0Device, 0, 0x00AAAA00, 0x00FFFF00))
+            .WillRepeatedly(Return(-1));
+
+        CFAMAccess cfam{0, driver};
+
+        cfam::ModifyOp op{cfam::ScratchPadReg::one, 0x00AAAA00, 0x00FFFF00};
+        EXPECT_EQ(cfam.writeScratchRegWithMask(op), -1);
+    }
 }


### PR DESCRIPTION
1. Add 10 total attempts forn CFAM read/write/writeWithMask before considering it a failure.
2. Add the same number of attempts when checking if if the sibling CFAM device is present.
3. Put the sibling CFAM device presence on D-Bus using the Availability interface.

When an FSI scan runs it destroys and recreates all CFAMs, so these commits protect against that being seen as a hard failure.

The new Available property will be used on systems that don't have sibling presence GPIOs to know if there is another BMC present.