### PR TITLE
cbs: switch starthost to use targeting

### DIFF
--- a/extensions/phal/create_pel.cpp
+++ b/extensions/phal/create_pel.cpp
@@ -120,7 +120,7 @@ void createErrorPEL(const std::string& event, const json& calloutData,
     catch (const sdbusplus::exception_t& e)
     {
         log<level::ERR>(
-            std::format("D-Bus call exception",
+            std::format("D-Bus call exception"
                         "OBJPATH={}, INTERFACE={}, event={}, EXCEPTION={}",
                         loggingObjectPath, loggingInterface, event, e.what())
                 .c_str());
@@ -224,7 +224,7 @@ uint32_t createSbeErrorPEL(const std::string& event, const sbeError_t& sbeError,
     catch (const sdbusplus::exception_t& e)
     {
         log<level::ERR>(
-            std::format("D-Bus call exception",
+            std::format("D-Bus call exception"
                         "OBJPATH={}, INTERFACE={}, EXCEPTION={}",
                         loggingObjectPath, loggingInterface, e.what())
                 .c_str());
@@ -302,7 +302,7 @@ uint32_t createPstSbeErrorPEL(const errl::ErrlEntry* errlEntry)
     catch (const sdbusplus::exception_t& e)
     {
         log<level::ERR>(
-            std::format("D-Bus call exception",
+            std::format("D-Bus call exception"
                         "OBJPATH={}, INTERFACE={}, EXCEPTION={}",
                         loggingObjectPath, loggingInterface, e.what())
                 .c_str());
@@ -343,7 +343,7 @@ void createPEL(const std::string& event, const FFDCData& ffdcData,
     catch (const sdbusplus::exception_t& e)
     {
         log<level::ERR>(
-            std::format("sdbusplus D-Bus call exception",
+            std::format("sdbusplus D-Bus call exception"
                         "OBJPATH={}, INTERFACE={}, EXCEPTION={}",
                         loggingObjectPath, loggingInterface, e.what())
                 .c_str());

--- a/extensions/phal/dump_utils.cpp
+++ b/extensions/phal/dump_utils.cpp
@@ -144,7 +144,7 @@ void requestDump(const DumpParameters& dumpParameters)
     }
     catch (const sdbusplus::exception_t& e)
     {
-        log<level::ERR>(std::format("D-Bus call createDump exception",
+        log<level::ERR>(std::format("D-Bus call createDump exception"
                                     "OBJPATH={}, INTERFACE={}, EXCEPTION={}",
                                     path, interface, e.what())
                             .c_str());

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,9 @@ project(
     version: '1.0',
     meson_version: '>=1.1.1',
 )
+
+#do not fail on the ABI warning in <format> from stdplus/fmt
+add_project_arguments('-Wno-error=format-security', language: 'cpp')
 add_project_arguments('-Wno-psabi', language: 'cpp')
 
 if get_option('cpp_std') != 'c++23'
@@ -225,7 +228,6 @@ executable(
         phosphor_logging_dep,
         sdbusplus_dep,
         dependency('threads'),
-        dependency('fmt'),
     ] + extra_dependencies,
     install: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,10 @@ if build_phal
         cxx.find_library('ipl'),
         cxx.find_library('phal'),
         cxx.find_library('dtree'),
+        cxx.find_library('targeting'),
+        cxx.find_library('targetsvc'),
+        cxx.find_library('hwaccess'),
+        cxx.find_library('transport'),
     ]
     extra_unit_files = [
         'service_files/set-spi-mux.service',

--- a/procedures/phal/start_host.cpp
+++ b/procedures/phal/start_host.cpp
@@ -268,7 +268,9 @@ void startHost(enum ipl_type iplType = IPL_TYPE_NORMAL)
 {
     try
     {
-        phal_init();
+        //TODO p12-refactor need to use env variable here for dtb
+        TargetService::instance().init("/tmp/targeting_test.dtb");
+
         ipl_set_type(iplType);
 
         /**

--- a/procedures/phal/start_host.cpp
+++ b/procedures/phal/start_host.cpp
@@ -1,8 +1,3 @@
-extern "C"
-{
-#include <libpdbg.h>
-}
-
 #include "attributes_info.H"
 
 #include "extensions/phal/common_utils.hpp"
@@ -11,6 +6,12 @@ extern "C"
 #include "util.hpp"
 
 #include <libekb.H>
+#include <targeting/predicates/predicateattrval.H>
+#include <targeting/predicates/predicatepostfixexpr.H>
+#include <targeting/target.H>
+#include <targeting/target_service.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include <targeting/xmltohb/attributetraits.H>
 
 #include <ext_interface.hpp>
 #include <nlohmann/json.hpp>
@@ -25,7 +26,7 @@ namespace phal
 {
 
 using namespace phosphor::logging;
-
+using namespace TARGETING;
 /**
  *  @brief  Select BOOT SEEPROM and Measurement SEEPROM(PRIMARY/BACKUP) on POWER
  *          processor position 0/1 depending on boot count before kicking off
@@ -35,17 +36,19 @@ using namespace phosphor::logging;
  */
 void selectBootSeeprom()
 {
-    struct pdbg_target* procTarget;
     ATTR_BACKUP_SEEPROM_SELECT_Enum bkpSeePromSelect;
     ATTR_BACKUP_MEASUREMENT_SEEPROM_SELECT_Enum bkpMeaSeePromSelect;
 
-    pdbg_for_each_class_target("proc", procTarget)
+    PredicatePostfixExpr pred;
+    pred.push(std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC))
+        .push(std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(
+            ENUM_ATTR_PROC_MASTER_TYPE_ACTING_MASTER))
+        .And();
+    auto top = TargetService::instance().getTopLevelTarget();
+    for (auto&& tgt : TargetService::instance().getAssociated(
+             top, AssociationType::childByPhysical, RecursionLevel::immediate,
+             &pred))
     {
-        if (!isPrimaryProc(procTarget))
-        {
-            continue;
-        }
-
         // Choose seeprom side to boot from based on boot count
         if (getBootCount() > 0)
         {
@@ -67,27 +70,9 @@ void selectBootSeeprom()
                 ENUM_ATTR_BACKUP_MEASUREMENT_SEEPROM_SELECT_SECONDARY;
         }
 
-        // Set the Attribute as per bootcount policy for boot seeprom
-        if (DT_SET_PROP(ATTR_BACKUP_SEEPROM_SELECT, procTarget,
-                        bkpSeePromSelect))
-        {
-            log<level::ERR>(
-                "Attribute [ATTR_BACKUP_SEEPROM_SELECT] set failed");
-            throw std::runtime_error(
-                "Attribute [ATTR_BACKUP_SEEPROM_SELECT] set failed");
-        }
-
-        // Set the Attribute as per bootcount policy for measurement seeprom
-        if (DT_SET_PROP(ATTR_BACKUP_MEASUREMENT_SEEPROM_SELECT, procTarget,
-                        bkpMeaSeePromSelect))
-        {
-            log<level::ERR>(
-                "Attribute [ATTR_BACKUP_MEASUREMENT_SEEPROM_SELECT] set "
-                "failed");
-            throw std::runtime_error(
-                "Attribute [ATTR_BACKUP_MEASUREMENT_SEEPROM_SELECT] set "
-                "failed");
-        }
+        tgt->setAttr<ATTR_BACKUP_SEEPROM_SELECT>(bkpSeePromSelect);
+        tgt->setAttr<ATTR_BACKUP_MEASUREMENT_SEEPROM_SELECT>(
+            bkpMeaSeePromSelect);
     }
 }
 
@@ -154,18 +139,13 @@ void setClkNETerminationSite()
         clockTerm = ENUM_ATTR_SYS_CLK_NE_TERMINATION_SITE_PROC;
     }
 
-    // update all the processor attributes
-    struct pdbg_target* procTarget;
-    pdbg_for_each_class_target("proc", procTarget)
+    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
+    auto top = TargetService::instance().getTopLevelTarget();
+    for (auto&& target : TargetService::instance().getAssociated(
+             top, AssociationType::childByPhysical, RecursionLevel::immediate,
+             &pred))
     {
-        if (DT_SET_PROP(ATTR_SYS_CLK_NE_TERMINATION_SITE, procTarget,
-                        clockTerm))
-        {
-            log<level::ERR>(
-                "Attribute ATTR_SYS_CLK_NE_TERMINATION_SITE set failed");
-            throw std::runtime_error(
-                "Attribute ATTR_SYS_CLK_NE_TERMINATION_SITE set failed");
-        }
+        target->setAttr<ATTR_SYS_CLK_NE_TERMINATION_SITE>(clockTerm);
     }
 }
 


### PR DESCRIPTION
Refactor starthost implementation to remove pdbg dependencies and switch to the targeting-based APIs for host initialization.

This change updates all methods within starthost that previously used pdbg interfaces to now use TARGETING::Target and related helpers, improving consistency and reducing external dependencies.

Future work may include additional cleanup once all pdbg usage is fully deprecated.

Change-Id: I73e724db5dd3565de8ccab0a334b8733804525ea