### PR TITLE
ecmd: Initial support for running iSteps

### DIFF
--- a/ecmd-plugin/README.md
+++ b/ecmd-plugin/README.md
@@ -1,0 +1,146 @@
+
+# **Move eCMD-pdbg Functionality to openpower-proc-control**
+
+**Author:** Marri Devender Rao  
+**Primary Assignee:** Marri Devender Rao  
+**Contributors:** None  
+**Date Created:** 10 November 2025  
+
+---
+
+## **1. Problem Description**
+
+Currently, **ecmd-pdbg** is tightly coupled with the **eCMD** repository and cannot be built or maintained independently.  
+The existing **ecmd-pdbg** recipe pulls the eCMD repository as a submodule and builds both the `ecmd` binaries and DLL.
+
+Since both **eCMD** and **ecmd-pdbg** reside in the **open-power** layer, they cannot interact with **systemd**, preventing them from creating or committing **PELs (Platform Error Logs)**.
+
+For next-generation **P12 systems**, which support multiple sleds requiring simultaneous power-on through a **systemd service**, it is essential to move the **ecmd-pdbg** functionality into **openpower-proc-control** (OpenBMC layer). This allows access to systemd and host firmware interfaces.
+
+By relocating ecmd-pdbg, the new plugin will directly access:
+- The **hostfw** repository for hardware access (scoms, cfams) and hardware procedures.
+
+**Reference Links:**  
+- [eCMD-pdbg Repository (Internal)](https://github.ibm.com/open-power/ecmd-pdbg)  
+- [eCMD Repository (Open Source)](https://github.com/open-power/eCMD)  
+- [openpower-proc-control Repository](https://github.com/ibm-openbmc/openpower-proc-control)
+
+---
+
+## **2. Objective**
+
+The goal is to **decouple eCMD from ecmd-pdbg ** and build eCMD independently.
+
+- eCMD will generate the header file `ecmdDllCapi.H`, defining the interface for client plugins.  
+- Client layers (like openpower-proc-control) will implement this interface.  
+- When an eCMD command (e.g., `ecmd istep`) is executed, eCMD dynamically loads the plugin defined by the environment variable:
+
+  ```bash
+  export ECMD_DLL_FILE=/usr/lib/libecmd-plugin.so
+  ```
+
+The implementation of `ecmdDllCapi.H` will now reside within **openpower-proc-control** as an **eCMD plugin**.
+
+---
+
+## **3. Background**
+
+In the current setup, **ecmd-pdbg** depends on eCMD as a submodule, restricting flexibility and preventing systemd access.  
+For **P12 multi-sled systems**, **openpower-proc-control** (running under systemd) manages power-on across sleds.  
+Embedding eCMD integration here allows reuse of existing eCMD command-line functionality and direct access to host firmware APIs.
+
+---
+
+## **4. Requirements**
+
+- Implement all functions defined in `ecmdDllCapi.H` within **openpower-proc-control** as an `ecmd-plugin`.  
+- Ensure compatibility with eCMD binary interface and dynamic loading mechanism.  
+- Support existing eCMD commands such as:
+  - `getcfam`
+  - `putscom`
+  - `query`
+  - `istep`
+
+---
+
+## **5. Proposed Design**
+
+### **a. Build System and Recipe Changes**
+
+- **ecmd bitbake recipe**
+  - Build **eCMD** as an independent application.
+  - Generate `ecmdDllCapi.H` for clients.
+
+- **openpower-proc-control bitbake recipe**
+  - Add dependency on `ecmd` recipe.
+  - Include and build the **ecmd-plugin** implementing `ecmdDllCapi.H`.
+
+---
+
+### **b. eCMD Plugin Implementation**
+
+- Implement all APIs defined in `ecmdDllCapi.H` inside a new module:
+  ```
+  openpower-proc-control/ecmd-plugin/
+  ```
+- eCMD dynamically loads this plugin using the `ECMD_DLL_FILE` environment variable.
+- The plugin:
+  - Provides hardware access via **hostfw** (scoms, cfams) and hardware procedures
+  - Integrates seamlessly with systemd for coordinated sled bring-up
+---
+
+## **7. Alternatives Considered**
+
+### **Option 1:**
+Re-implement eCMD-like utilities directly inside openpower-proc-control.
+
+**Drawbacks:**
+- Significant development and maintenance overhead  
+- Loss of mature eCMD CLI features  
+- Incompatibility with existing tools (e.g., Cronus)
+
+### **Option 2 (Chosen):**
+Reuse eCMD as-is, and re-implement only the plugin interface (`ecmdDllCapi.H`) in openpower-proc-control.
+
+---
+
+## **8. Implementation Details**
+
+- Add a new module:  
+  ```
+  openpower-proc-control/ecmd-plugin/
+  ```
+- Implement `ecmdDllCapi.H` API functions.  
+- Use **hostfw** APIs for SCOM/CFAM access and hardware procedures  
+- Validate plugin loading through:
+  ```bash
+  export ECMD_DLL_FILE=/usr/lib/libecmd-plugin.so
+  ecmd istep 11.1
+  ```
+- Integrate with systemd services for multi-sled bring-up.
+
+---
+
+## **9. Testing Plan**
+
+| **Test Case** | **Command** | **Expected Result** |
+|----------------|-------------|---------------------|
+| CFAM Read | `ecmd getcfam` | CFAM register read successful |
+| SCOM Write | `ecmd putscom` | SCOM register write successful |
+| Target Query | `ecmd query` | Target list displayed correctly |
+| ISTEP Execution | `ecmd istep` | ISTEP executed via plugin successfully |
+
+Successful completion of these validates end-to-end integration of **eCMD → ecmd-plugin → hostfw** under **systemd** orchestration.
+
+---
+
+## **10. Expected Outcome**
+
+After migration:
+- **ecmd-pdbg** functionality will reside in **openpower-proc-control**.  
+- It will have full access to **systemd**, **hostfw**, and **multi-sled orchestration**.  
+- The system will maintain eCMD’s command-line flexibility while enabling scalable next-generation bring-up workflows.
+---
+
+✅ **Final Benefit:**  
+This refactoring ensures **better modularity, reusability, and integration** with OpenBMC services while preserving the rich eCMD feature set.

--- a/ecmd-plugin/ecmd_dll_capi.cpp
+++ b/ecmd-plugin/ecmd_dll_capi.cpp
@@ -1,0 +1,106 @@
+#include <ecmdReturnCodes.H>
+#include <ecmdStructs.H>
+#include <unistd.h>
+extern "C"
+{
+#include <libpdbg.h>
+}
+#include <phosphor-logging/lg2.hpp>
+
+extern "C"
+{
+uint32_t dllInitDll()
+{
+    const char* dtbPath = getenv("PDBG_DTB");
+    if (!dtbPath)
+    {
+        lg2::error("Failed to get PDBG_DTB env variable");
+        return -1;
+    }
+    const char* ecmdExe = getenv("ECMD_EXE");
+    if (!ecmdExe)
+    {
+        lg2::error("Failed to get ECMD_EXE env variable");
+        return -1;
+    }
+
+    pdbg_targets_init(NULL);
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllFreeDll()
+{
+    return ECMD_SUCCESS;
+}
+uint32_t dllLoadDll(const char*, uint32_t)
+{
+    return dllInitDll();
+}
+
+uint32_t dllUnloadDll()
+{
+    uint32_t rc = 0;
+    rc = dllFreeDll();
+    return rc;
+}
+
+void dllOutputError(const char* err)
+{
+    lg2::error("error {ERR}", "ERR", err);
+}
+
+void dllOutputWarning(const char* err)
+{
+    lg2::warning("warning {ERR}", "ERR", err);
+}
+
+uint32_t dllDelay(uint32_t, uint32_t msDelay)
+{
+    uint32_t rc = usleep(msDelay * 1000);
+    if (rc != 0)
+    {
+        lg2::error("dllDelay usleep failed");
+    }
+    return rc;
+}
+//---------------------------------------------------------------------
+// optional methods the plugin can choose to add implementation
+//---------------------------------------------------------------------
+void dllOutput(const char*) {}
+
+uint32_t dllGetGlobalVar(ecmdGlobalVarType_t)
+{
+    return ECMD_SUCCESS;
+}
+uint32_t dllQueryDllInfo(ecmdDllInfo&)
+{
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllCheckDllVersion(const char*)
+{
+    return ECMD_SUCCESS;
+}
+
+bool dllQueryVersionGreater(const char*)
+{
+    return false;
+}
+
+std::string dllGetCurrentCmdline()
+{
+    return {};
+}
+
+void dllSetCurrentCmdline(int, [[maybe_unused]] char* argv[]) {}
+
+uint32_t dllSetGlobalVar(ecmdGlobalVarType_t, uint32_t)
+{
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllCommonCommandArgs(int*, [[maybe_unused]] char** argv[])
+{
+    return ECMD_SUCCESS;
+}
+} // extern "C"

--- a/ecmd-plugin/ecmd_dll_error.cpp
+++ b/ecmd-plugin/ecmd_dll_error.cpp
@@ -1,0 +1,48 @@
+#include <ecmdDataBuffer.H>
+#include <ecmdReturnCodes.H>
+#include <ecmdStructs.H>
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <cstdint>
+extern "C"
+{
+//---------------------------------------------------------------------
+// optional methods the plugin can choose to add implementation
+//---------------------------------------------------------------------
+std::string dllGetErrorMsg(uint32_t, bool, bool, bool)
+{
+    return {};
+}
+
+uint32_t dllRegisterErrorMsg(uint32_t, const char*, const char*)
+{
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllFlushRegisteredErrorMsgs(uint32_t)
+{
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllFlushRegisteredErrorMsgsString(uint32_t, std::string)
+{
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllGetErrorTarget(uint32_t, std::list<ecmdChipTarget>&, bool)
+{
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllRegisterErrorTarget(uint32_t, const ecmdChipTarget&)
+{
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllFlushRegisteredErrorTargets(uint32_t)
+{
+    return ECMD_SUCCESS;
+}
+
+} // extern "C"

--- a/ecmd-plugin/ecmd_dll_istep.cpp
+++ b/ecmd-plugin/ecmd_dll_istep.cpp
@@ -1,0 +1,189 @@
+#include <ecmdDataBuffer.H>
+#include <ecmdReturnCodes.H>
+#include <ecmdStructs.H>
+#include <libipl.H>
+
+#include <ecmd_util.hpp>
+#include <istep_table.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+extern "C"
+{
+uint32_t executeIstep(uint16_t major, uint16_t minorStart, uint16_t minorEnd)
+{
+    lg2::info(
+        "executeIstep major={MAJOR} minorstart={MINOR_START} minorend={MINOR_END} ",
+        "MAJOR", major, "MINOR_START", minorStart, "MINOR_END", minorEnd);
+    using namespace istep_table;
+    uint32_t rc = ECMD_SUCCESS;
+
+    // If istep is 0 then, run chassis on and other workaround steps before
+    // kick off ipl_run_major_minor() in loop
+    if (major == 0)
+    {
+        /* istep power on */
+        rc = ecmd_util::istepPowerOn();
+        if (!rc)
+        {
+            // Set IPL mode to interactive
+            rc = ipl_init(IPL_HOSTBOOT);
+            if (rc)
+            {
+                lg2::error("Unable to set IPL in interactive mode");
+                return rc;
+            }
+        }
+        else
+        {
+            lg2::error("FAIL: istepPowerOn");
+            return rc;
+        }
+    } // major ==0
+    /* loop through each isteps */
+    for (uint16_t minor = minorStart; minor <= minorEnd; minor++)
+    {
+        auto istepNameOpt = istep_table::getStepName(major, minor);
+        if (!istepNameOpt)
+        {
+            lg2::error("Invalid istep major={MAJOR} minor={MINOR}", "MAJOR",
+                       major, "MINOR", minor);
+            continue;
+        }
+        IStepDestination destination = getDestination(major, minor);
+
+        // This istep is NOOP
+        if (destination == IStepDestination::EDBG_ISTEP_NOOP)
+        {
+            lg2::error("Requested istep {STEP} is noop", "STEP", *istepNameOpt);
+        }
+        else
+        {
+            /* kick off isteps */
+            rc = ipl_run_major_minor(major, minor);
+            if (!rc)
+            {
+                if (major == 6 && minor == 4)
+                {
+                    // if the istep reaches 6.4 then, set the Host state to
+                    // running!
+                    rc = ecmd_util::setHostStateToRunning();
+                    if (rc != ECMD_SUCCESS)
+                    {
+                        lg2::error("FAIL: failed to set host state");
+                        return rc;
+                    }
+                }
+                lg2::error("PASS: istep {STEP}", "STEP", *istepNameOpt);
+            }
+            else
+            {
+                lg2::error("FAIL: istep check Error {STEP}", "STEP",
+                           *istepNameOpt);
+                return rc;
+            }
+        }
+    } // end for
+    return rc;
+}
+
+uint32_t dllIStepsByNumber(const ecmdDataBuffer& isteps)
+{
+    using namespace istep_table;
+
+    uint32_t rc = ECMD_SUCCESS;
+
+    do // Start of single exit point loop.
+    {
+        /****************************************************************************************/
+        /* First, check to make sure at least 1 bit is active in i_steps
+         * databuffer, then....   */
+        /* For each valid bit in the i_steps databuffer: */
+        /*   1)  find the index entry #s that start that step and end that
+         * step */
+        /*   2)  Call iStepsHelper()  multiple times, starting with starting
+         * index entry #    */
+        /*        and ending with the ending entry #. */
+        /****************************************************************************************/
+        // check to see if at least 1 bit in the range is active
+        uint32_t count = isteps.getNumBitsSet(
+            EDBG_FIRST_ISTEP_NUM,
+            EDBG_LAST_ISTEP_NUM - EDBG_FIRST_ISTEP_NUM + 1);
+        if (count == 0)
+        {
+            rc = ECMD_INVALID_ARGS;
+            lg2::error("No Steps in active range selected {FIRST} to {LAST}",
+                       "FIRST", EDBG_FIRST_ISTEP_NUM, "LAST",
+                       EDBG_LAST_ISTEP_NUM);
+            break; // exit do-loop
+        }
+        else
+        {
+            lg2::debug("number of isteps bits set is {COUNT}", "COUNT", count);
+        }
+
+        uint16_t activeStep = EDBG_INVALID_ISTEP_NUM;
+        /* Large 'for' loop that goes through i_steps looking for active
+         * steps start at begining of range */
+        for (activeStep = EDBG_FIRST_ISTEP_NUM;
+             activeStep <= EDBG_LAST_ISTEP_NUM && rc == ECMD_SUCCESS;
+             ++activeStep)
+        {
+            if (isteps.isBitSet(activeStep)) // this is an active step
+            {
+                /*  look IPLTable for the existence of this istep number */
+                if (false == isValid(activeStep))
+                {
+                    /* this is only warning, as the value is in the range,
+                     * but isn't being used */
+                    lg2::error("Requested iStep Number {STEP} is invalid",
+                               "STEP", activeStep);
+                    continue;
+                }
+
+                /* 1a) Lookup first index entry of this active step */
+                uint16_t indexBegin = getPosFirstMinorNumber(activeStep);
+                uint16_t minorStart = getIStepMinorNumber(indexBegin);
+
+                /* 1b) Starting with indexBegin,
+                 *     lookup last index entry of this active step */
+                uint16_t indexEnd = getPosLastMinorNumber(activeStep);
+                uint16_t minorEnd = getIStepMinorNumber(indexEnd);
+
+                /* 2) Call iStepsHelper()  multiple times,
+                 *    starting with starting index entry #
+                 *    and ending with the ending entry #. */
+                /* kick off isteps */
+                rc = executeIstep(activeStep, minorStart, minorEnd);
+                if (rc)
+                {
+                    lg2::error("error in executeIstep");
+                    break;
+                }
+            } /*  end of 'if' active step check */
+        } /* end of for loop going through active i_steps */
+    } while (0);
+
+    return rc;
+}
+
+uint32_t dllIStepsByName(std::string stepName)
+{
+    lg2::info("dllIStepsByName name {STEP} not implemented", "STEP", stepName);
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllIStepsByNameMultiple(std::list<std::string>)
+{
+    lg2::info("dllIStepsByNameMultiple not implemented");
+    return ECMD_SUCCESS;
+}
+
+uint32_t dllIStepsByNameRange(std::string begin, std::string end)
+{
+    // TODO: Refer to edbgEcmdDll.C and add relevant code here
+    lg2::info("dllIStepsByNameRange {BEGIN} to {END}", "BEGIN", begin, "END",
+              end);
+    lg2::error("dllIStepsByNameRange not implemented");
+    return ECMD_FUNCTION_NOT_SUPPORTED;
+}
+} // extern "C"

--- a/ecmd-plugin/ecmd_dll_ring.cpp
+++ b/ecmd-plugin/ecmd_dll_ring.cpp
@@ -1,0 +1,16 @@
+#include <ecmdDataBuffer.H>
+#include <ecmdStructs.H>
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <cstdint>
+extern "C"
+{
+//---------------------------------------------------------------------
+// optional methods the plugin can choose to add implementation
+//---------------------------------------------------------------------
+bool dllIsRingCacheEnabled(const ecmdChipTarget&)
+{
+    return false;
+}
+}

--- a/ecmd-plugin/ecmd_util.cpp
+++ b/ecmd-plugin/ecmd_util.cpp
@@ -1,0 +1,185 @@
+#include <ecmdReturnCodes.H>
+
+#include <ecmd_util.hpp>
+
+#include <thread>
+extern "C"
+{
+#include <libpdbg.h>
+}
+#include <phosphor-logging/lg2.hpp>
+
+namespace fs = std::filesystem;
+
+namespace ecmd_util
+{
+constexpr auto GENESIS_BOOT_FILE = "/var/lib/phal/genesisboot";
+
+bool isFunctionalTarget(struct pdbg_target* target)
+{
+    uint8_t buf[5];
+    bool isFunc = false;
+
+    if (!pdbg_target_get_attribute_packed(target, "ATTR_HWAS_STATE", "41", 1,
+                                          buf))
+    {
+        lg2::error("ATTR_HWAS_STATE Attribute get failed");
+        isFunc = false;
+    }
+
+    // isFuntional bit is stored in 4th byte and bit 3 position in HWAS_STATE
+    if (buf[4] & 0x20)
+    {
+        isFunc = true;
+    }
+
+    return isFunc;
+}
+
+// Check if chassis is on/off
+bool isChassisOn()
+{
+    constexpr std::string_view cmd = "obmcutil chassisstate 2>&1";
+    std::array<char, 128> buffer{};
+    std::string output;
+
+    // Define unique_ptr with custom deleter for FILE*
+    using FileCloser = int (*)(FILE*);
+
+    auto pipePtr =
+        std::unique_ptr<FILE, FileCloser>(popen(cmd.data(), "r"), pclose);
+    if (!pipePtr)
+    {
+        lg2::error("Failed to execute command {CMD}", "CMD", cmd);
+        return false;
+    }
+
+    // Read command output
+    while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipePtr.get()))
+    {
+        output += buffer.data();
+    }
+
+    // Return true if the chassis is ON, false otherwise
+    return output.contains("State.Chassis.PowerState.On");
+}
+
+int startAttnHandler()
+{
+    int rc = ECMD_SUCCESS;
+    std::string cmd = "systemctl start attn_handler.service";
+
+    // User the system handler service
+    rc = system(cmd.c_str());
+    if (rc != 0)
+    {
+        lg2::error("Failed to execute system command {CMD}", "CMD", cmd);
+        rc = -errno;
+        return rc;
+    }
+
+    return rc;
+}
+
+int istepPowerOn()
+{
+    lg2::info("enter istepPowerOn");
+    int rc = ECMD_SUCCESS;
+    const std::string host_reboot_off_cmd = "obmcutil hostrebootoff";
+    const std::string chassis_on_cmd = "obmcutil --wait chassison";
+    const std::string mbox_reset_cmd = "/usr/sbin/mboxctl --reset";
+
+    bool chassisOn = isChassisOn();
+    uint16_t count = 0;
+
+    if (!chassisOn)
+    {
+        // Disable host recovery (istep mode)
+        rc = std::system(host_reboot_off_cmd.c_str());
+        if (rc != 0)
+        {
+            rc = -errno;
+            return rc;
+        }
+
+        // Trigger chassis on
+        rc = std::system(chassis_on_cmd.c_str());
+        if (rc != 0)
+        {
+            rc = -errno;
+            return rc;
+        }
+
+        // Wait up to 3 minutes for chassis to turn ON
+        do
+        {
+            chassisOn = isChassisOn();
+            if (chassisOn)
+                break;
+
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        } while (++count < 180);
+    }
+
+    // Check final state
+    if (!chassisOn)
+    {
+        return -1; // chassis did not power on
+    }
+
+    // Trigger mbox reset
+    rc = std::system(mbox_reset_cmd.c_str());
+    if (rc != 0)
+    {
+        rc = -errno;
+        return rc;
+    }
+
+    // Remove genesis boot file if it exists
+    fs::path genesis_boot_file = GENESIS_BOOT_FILE;
+    if (fs::exists(genesis_boot_file))
+    {
+        fs::remove(genesis_boot_file);
+    }
+
+    // Start attention handler service
+    rc = startAttnHandler();
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    return ECMD_SUCCESS;
+}
+
+// Set host state to running
+int setHostStateToRunning()
+{
+    // TODO:use D-Bus method
+    const std::string cmd =
+        "busctl set-property "
+        "xyz.openbmc_project.State.Host "
+        "/xyz/openbmc_project/state/host0 "
+        "xyz.openbmc_project.State.Host "
+        "CurrentHostState s "
+        "xyz.openbmc_project.State.Host.HostState.Running";
+
+    // Try to set host state to Running
+    int rc = std::system(cmd.c_str());
+    if (rc != 0)
+    {
+        lg2::error("Failed to set host state running {CMD}", "CMD", cmd);
+        return rc;
+    }
+
+    // Best-effort: stop systemd targets; ignore errors
+    const std::string stopCmd = "obmcutil stopofftargets";
+    rc = std::system(stopCmd.c_str());
+    if (rc != 0)
+    {
+        lg2::error("Failed to execute command {CMD}", "CMD", stopCmd);
+        return rc;
+    }
+    return ECMD_SUCCESS;
+}
+} // namespace ecmd_util

--- a/ecmd-plugin/ecmd_util.hpp
+++ b/ecmd-plugin/ecmd_util.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <string>
+
+namespace ecmd_util
+{
+
+bool isChassisOn();
+
+int startAttnHandler();
+
+// Trigger obmcutil hostrebootoff->chassison->wait for chassison()
+int istepPowerOn();
+
+// Set host state to running
+int setHostStateToRunning();
+} // namespace ecmd_util

--- a/ecmd-plugin/istep_table.hpp
+++ b/ecmd-plugin/istep_table.hpp
@@ -1,0 +1,409 @@
+#pragma once
+
+//--------------------------------------------------------------------
+// Includes
+//--------------------------------------------------------------------
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <ranges>
+#include <string>
+namespace istep_table
+{
+// ---------------------------------------------------------------------
+// Strongly-typed destination enum
+// ---------------------------------------------------------------------
+enum class IStepDestination : std::uint8_t
+{
+    EDBG_ISTEP_HOST = 0x0, // IStep is executed by host
+    EDBG_ISTEP_SBE,        // IStep is executed by Self Boot Engine
+    EDBG_ISTEP_BMC,        // IStep is executed by BMC
+    EDBG_ISTEP_NOOP,       // This istep is NOOP
+    EDBG_ISTEP_INVALID_DESTINATION
+};
+
+// ---------------------------------------------------------------------
+// IPL Step structure
+// ---------------------------------------------------------------------
+struct IStep
+{
+    std::uint16_t major{};
+    std::uint16_t minor{};
+    std::string_view name{};
+    IStepDestination dest{};
+};
+
+/****************************************************************************/
+/* !!! --- THIS LIST MUST BE IN ORDER THAT THEY'RE CALLED IN AN IPL --- !!! */
+/****************************************************************************/
+
+/****************************************************************************/
+/* NOTE: The istep is executed by the self boot engine/the host code/       */
+/*       the attached bmc depending upon the destination type.              */
+/*       Options:                                                           */
+/*       EDBG_ISTEP_HOST - The istep is performed by the host               */
+/*       EDBG_ISTEP_SBE  - The istep is performed by the self boot engine   */
+/*       EDBG_ISTEP_BMC  - The istep is performed by the BMC                */
+/*       EDBG_ISTEP_NOOP - The istep is No OP                               */
+/*                                                                          */
+/****************************************************************************/
+
+/****************************************************************************/
+/* Warning : The following constants are defined based on the values of this*/
+/*           table. Any changes to this table requires examination of the   */
+/*           values assigned to these constants.                            */
+/*                                                                          */
+/*       EDBG_FIRST_ISTEP_NUM   = 0                                         */
+/*       EDBG_LAST_ISTEP_NUM    = 21                                        */
+/*       EDBG_INVALID_ISTEP_NUM = 0xFFFF                                    */
+/*       EDBG_INVALID_POSITION  = 0xFFFF                                    */
+/****************************************************************************/
+// major | minor |                          istep name   | destination   |
+// number| number|                                       | |
+inline constexpr auto ISteps = std::to_array<IStep>({
+    {0, 1, "poweron", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 2, "startipl", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 3, "disableattns", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 4, "updatehwmodel", IStepDestination::EDBG_ISTEP_BMC},
+    {0, 5, "alignment_check", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 6, "set_ref_clock", IStepDestination::EDBG_ISTEP_BMC},
+    {0, 7, "proc_clock_test", IStepDestination::EDBG_ISTEP_BMC},
+    {0, 8, "proc_prep_ipl", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 9, "edramrepair", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 10, "asset_protection", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 11, "proc_select_boot_prom", IStepDestination::EDBG_ISTEP_BMC},
+    {0, 12, "hb_config_update", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 13, "sbe_config_update", IStepDestination::EDBG_ISTEP_BMC},
+    {0, 14, "sbe_start", IStepDestination::EDBG_ISTEP_BMC},
+    {0, 15, "startprd", IStepDestination::EDBG_ISTEP_NOOP},
+    {0, 16, "proc_attn_listen", IStepDestination::EDBG_ISTEP_BMC},
+    {1, 1, "proc_sbe_enable_seeprom", IStepDestination::EDBG_ISTEP_NOOP},
+    {1, 2, "proc_sbe_pib_init", IStepDestination::EDBG_ISTEP_NOOP},
+    {1, 3, "proc_sbe_measure", IStepDestination::EDBG_ISTEP_NOOP},
+    {2, 1, "proc_sbe_ld_image", IStepDestination::EDBG_ISTEP_NOOP},
+    {2, 2, "proc_sbe_attr_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 3, "proc_sbe_tp_dpll_bypass", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 4, "proc_sbe_tp_chiplet_reset", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 5, "proc_sbe_tp_gptr_time_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 6, "proc_sbe_dft_probe_setup_1", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 7, "proc_sbe_npll_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 8, "proc_sbe_rcs_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 9, "proc_sbe_tp_switch_gears", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 10, "proc_sbe_npll_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 11, "proc_sbe_tp_repr_intf", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 12, "proc_sbe_setup_tp_abist", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 13, "proc_sbe_tp_arrayinit", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 14, "proc_sbe_tp_intf", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 15, "proc_sbe_dft_probesetup_2", IStepDestination::EDBG_ISTEP_SBE},
+    {2, 16, "proc_sbe_tp_chiplet_init", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 1, "proc_sbe_chiplet_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 2, "proc_sbe_chiplet_clk_config", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 3, "proc_sbe_chiplet_reset", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 4, "proc_sbe_gptr_time_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 5, "proc_sbe_chiplet_pll_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 6, "proc_sbe_chiplet_pll_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 7, "proc_sbe_repr_intf", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 8, "proc_sbe_abist_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 9, "proc_sbe_arrayinit", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 10, "proc_sbe_lbist", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 11, "proc_sbe_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 12, "proc_sbe_startclocks", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 13, "proc_sbe_chiplet_init", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 14, "proc_sbe_chiplet_fir_init", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 15, "proc_sbe_dts_init", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 16, "proc_sbe_skew_adjust_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 17, "proc_sbe_nest_enable_ridi", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 18, "proc_sbe_scominit", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 19, "proc_sbe_lpc", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 20, "proc_sbe_fabricinit", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 21, "proc_sbe_check_boot_proc", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 22, "proc_sbe_mcs_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {3, 23, "proc_sbe_select_ex", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 1, "proc_hcd_cache_poweron", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 2, "proc_hcd_cache_reset", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 3, "proc_hcd_cache_gptr_time_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 4, "proc_hcd_cache_repair_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 5, "proc_hcd_cache_arrayinit", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 6, "proc_hcd_cache_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 7, "proc_hcd_cache_startclocks", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 8, "proc_hcd_cache_scominit", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 9, "proc_hcd_cache_scom_customize", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 10, "proc_hcd_cache_ras_runtime_scom",
+     IStepDestination::EDBG_ISTEP_SBE},
+    {4, 11, "proc_hcd_core_poweron", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 12, "proc_hcd_core_reset", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 13, "proc_hcd_core_gptr_time_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 14, "proc_hcd_core_repair_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 15, "proc_hcd_core_arrayinit", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 16, "proc_hcd_core_initf", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 17, "proc_hcd_core_startclocks", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 18, "proc_hcd_core_scominit", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 19, "proc_hcd_core_scom_customize", IStepDestination::EDBG_ISTEP_SBE},
+    {4, 20, "proc_hcd_core_ras_runtime_scom", IStepDestination::EDBG_ISTEP_SBE},
+    {5, 1, "proc_sbe_load_bootloader", IStepDestination::EDBG_ISTEP_SBE},
+    {5, 2, "proc_sbe_core_spr_setup", IStepDestination::EDBG_ISTEP_SBE},
+    {5, 3, "proc_sbe_instruct_start", IStepDestination::EDBG_ISTEP_SBE},
+    {6, 1, "host_bootloader", IStepDestination::EDBG_ISTEP_NOOP},
+    {6, 2, "host_setup", IStepDestination::EDBG_ISTEP_NOOP},
+    {6, 3, "host_istep_enable", IStepDestination::EDBG_ISTEP_NOOP},
+    {6, 4, "host_init_fsi", IStepDestination::EDBG_ISTEP_HOST},
+    {6, 5, "host_set_ipl_parms", IStepDestination::EDBG_ISTEP_HOST},
+    {6, 6, "host_discover_targets", IStepDestination::EDBG_ISTEP_HOST},
+    {6, 7, "host_update_primary_tpm", IStepDestination::EDBG_ISTEP_HOST},
+    {6, 8, "host_gard", IStepDestination::EDBG_ISTEP_HOST},
+    {6, 9, "host_voltage_config", IStepDestination::EDBG_ISTEP_HOST},
+    {7, 1, "host_mss_attr_cleanup", IStepDestination::EDBG_ISTEP_HOST},
+    {7, 2, "mss_volt", IStepDestination::EDBG_ISTEP_HOST},
+    {7, 3, "mss_freq", IStepDestination::EDBG_ISTEP_HOST},
+    {7, 4, "mss_eff_config", IStepDestination::EDBG_ISTEP_HOST},
+    {7, 5, "mss_attr_update", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 1, "host_setup_sbe", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 2, "host_secondary_sbe_config", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 3, "host_cbs_start", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 4, "proc_check_secondary_sbe_seeprom_complete",
+     IStepDestination::EDBG_ISTEP_HOST},
+    {8, 5, "host_attnlisten_proc", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 6, "host_fbc_eff_config", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 7, "hosteff_config_links", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 8, "proc_attr_update", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 9, "proc_chiplet_fabric_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 10, "host_set_voltages", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 11, "proc_io_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 12, "proc_load_ioppe", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 13, "proc_init_ioppe", IStepDestination::EDBG_ISTEP_HOST},
+    {8, 14, "proc_iohs_enable_ridi", IStepDestination::EDBG_ISTEP_HOST},
+    {9, 1, "proc_io_dccal_done", IStepDestination::EDBG_ISTEP_HOST},
+    {9, 2, "fabric_dl_pre_trainadv", IStepDestination::EDBG_ISTEP_HOST},
+    {9, 3, "fabric_dl_setup_training", IStepDestination::EDBG_ISTEP_HOST},
+    {9, 4, "proc_fabric_link_layer", IStepDestination::EDBG_ISTEP_HOST},
+    {9, 5, "fabric_dl_post_trainadv", IStepDestination::EDBG_ISTEP_HOST},
+    {9, 6, "proc_fabric_iovalid", IStepDestination::EDBG_ISTEP_HOST},
+    {9, 7, "proc_fbc_eff_config_aggregate", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 1, "proc_build_smp", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 2, "host_sbe_update", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 3, "host_secureboot_lockdown", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 4, "proc_chiplet_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 5, "proc_pau_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 6, "proc_pcie_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 7, "proc_scomoverride_chiplets", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 8, "proc_chiplet_enable_ridi", IStepDestination::EDBG_ISTEP_HOST},
+    {10, 9, "host_rng_bist", IStepDestination::EDBG_ISTEP_HOST},
+    {11, 1, "host_prd_hwreconfig", IStepDestination::EDBG_ISTEP_HOST},
+    {11, 2, "host_set_mem_volt", IStepDestination::EDBG_ISTEP_HOST},
+    {11, 3, "proc_ocmb_enable", IStepDestination::EDBG_ISTEP_HOST},
+    {11, 4, "ocmb_check_for_ready", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 1, "mss_getecid", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 2, "omi_attr_update", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 3, "proc_omi_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 4, "ocmb_omi_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 5, "omi_pre_trainadv", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 6, "omi_setup", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 7, "omi_io_run_training", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 8, "omi_train_check", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 9, "omi_post_trainadv", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 10, "host_attnlisten_memb", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 11, "host_omi_init", IStepDestination::EDBG_ISTEP_HOST},
+    {12, 12, "update_omi_firmaware", IStepDestination::EDBG_ISTEP_HOST},
+    {13, 1, "mss_scominit", IStepDestination::EDBG_ISTEP_HOST},
+    {13, 2, "mss_draminit", IStepDestination::EDBG_ISTEP_HOST},
+    {13, 3, "mss_draminit_mc", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 1, "mss_memdiag", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 2, "mss_thermal_init", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 3, "proc_load_iop_xram", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 4, "proc_pcie_config", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 5, "proc_setup_mmio_bars", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 6, "host_secure_rng", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 7, "host_enable_memory_encryption", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 8, "proc_exit_cache_contained", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 9, "proc_htm_setup", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 10, "host_mpipl_service", IStepDestination::EDBG_ISTEP_HOST},
+    {14, 11, "proc_psiinit", IStepDestination::EDBG_ISTEP_NOOP}, // cronus only
+    {14, 12, "proc_bmc_pciinit",
+     IStepDestination::EDBG_ISTEP_NOOP},                         // cronus only
+    {15, 1, "host_build_stop_image", IStepDestination::EDBG_ISTEP_HOST},
+    {15, 2, "proc_set_homer_bar", IStepDestination::EDBG_ISTEP_HOST},
+    {15, 3, "host_establish_ec_chiplet", IStepDestination::EDBG_ISTEP_HOST},
+    {15, 4, "host_start_stop_engine", IStepDestination::EDBG_ISTEP_HOST},
+    {16, 1, "host_activate_boot_core", IStepDestination::EDBG_ISTEP_HOST},
+    {16, 2, "host_activate_secondary_cores", IStepDestination::EDBG_ISTEP_HOST},
+    {16, 3, "host_secure_rng_noop", IStepDestination::EDBG_ISTEP_HOST},
+    {16, 4, "mss_scrub", IStepDestination::EDBG_ISTEP_HOST},
+    {16, 5, "host_ipl_complete", IStepDestination::EDBG_ISTEP_HOST},
+    {17, 1, "collect_drawers", IStepDestination::EDBG_ISTEP_NOOP},
+    {17, 2, "proc_psiinit", IStepDestination::EDBG_ISTEP_NOOP},
+    {17, 3, "psi_diag", IStepDestination::EDBG_ISTEP_NOOP},
+    {18, 1, "sys_proc_eff_config_links", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 2, "sys_proc_chiplet_fabric_scominit",
+     IStepDestination::EDBG_ISTEP_HOST},
+    {18, 3, "sys_fabric_dl_pre_trainadv", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 4, "sys_fabric_dl_setup_training", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 5, "sys_proc_fabric_link_layer", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 6, "sys_fabric_dl_post_trainadv", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 7, "sys_proc_fabric_iovalid", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 8, "sys_proc_fbc_eff_config_aggregate",
+     IStepDestination::EDBG_ISTEP_HOST},
+    {18, 9, "proc_tod_setup", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 10, "proc_tod_init", IStepDestination::EDBG_ISTEP_HOST},
+    {18, 11, "cec_ipl_complete", IStepDestination::EDBG_ISTEP_NOOP},
+    {18, 12, "startprd_system", IStepDestination::EDBG_ISTEP_NOOP},
+    {18, 13, "attn_listenall", IStepDestination::EDBG_ISTEP_NOOP},
+    {19, 1, "prep_host", IStepDestination::EDBG_ISTEP_NOOP},
+    {20, 1, "host_load_payload", IStepDestination::EDBG_ISTEP_HOST},
+    {20, 2, "host_load_complete", IStepDestination::EDBG_ISTEP_HOST},
+    {21, 1, "host_micro_update", IStepDestination::EDBG_ISTEP_HOST},
+    {21, 2, "host_runtime_setup", IStepDestination::EDBG_ISTEP_HOST},
+    {21, 3, "host_verify_hdat", IStepDestination::EDBG_ISTEP_HOST},
+    {21, 4, "host_start_payload", IStepDestination::EDBG_ISTEP_HOST},
+    {21, 5, "host_post_start_payload", IStepDestination::EDBG_ISTEP_NOOP},
+    {21, 6, "switchbcu", IStepDestination::EDBG_ISTEP_NOOP},
+    {21, 7, "completeipl", IStepDestination::EDBG_ISTEP_NOOP},
+}); // end - array initialization
+
+constexpr std::uint16_t EDBG_FIRST_ISTEP_NUM = 0;
+constexpr std::uint16_t EDBG_LAST_ISTEP_NUM = 21;
+constexpr std::uint16_t EDBG_INVALID_POSITION = 0xFFFF;
+constexpr std::uint16_t EDBG_NUMBER_OF_ISTEPS = ISteps.size();
+constexpr std::uint16_t EDBG_INVALID_ISTEP_NUM = 0xFFFF;
+
+constexpr std::optional<std::string_view> getStepName(uint16_t major,
+                                                      uint16_t minor)
+{
+    auto it = std::ranges::find_if(ISteps, [=](auto& s) {
+        return s.major == major && s.minor == minor;
+    });
+    if (it != ISteps.end())
+    {
+        return it->name;
+    }
+    return std::nullopt;
+}
+
+constexpr bool isValid(uint8_t majorNum)
+{
+    return std::ranges::any_of(ISteps, [=](auto& s) {
+        return s.major == majorNum;
+    });
+}
+
+constexpr bool isValid(std::string_view name)
+{
+    return std::ranges::any_of(ISteps, [=](auto& s) { return s.name == name; });
+}
+
+constexpr IStepDestination getDestination(uint16_t majorNum, uint16_t minorNum)
+{
+    if (auto it = std::ranges::find_if(ISteps,
+                                       [=](const IStep& step) {
+                                           return step.major == majorNum &&
+                                                  step.minor == minorNum;
+                                       });
+        it != ISteps.end())
+    {
+        return it->dest;
+    }
+
+    return IStepDestination::EDBG_ISTEP_INVALID_DESTINATION;
+}
+// ---------------------------------------------------------------------
+// Get the position (index) of the last minor number for a given major
+// ---------------------------------------------------------------------
+constexpr std::uint16_t getPosLastMinorNumber(std::uint16_t majorNum)
+{
+    if (majorNum > EDBG_LAST_ISTEP_NUM)
+    {
+        return EDBG_INVALID_POSITION;
+    }
+
+    std::uint16_t position = EDBG_INVALID_POSITION;
+
+    for (std::uint16_t row = 0; row < EDBG_NUMBER_OF_ISTEPS; ++row)
+    {
+        if (ISteps[row].major == majorNum)
+        {
+            // If this is the last row or next row has a greater major number,
+            // current row marks the last minor number for this major.
+            if ((row + 1 == EDBG_NUMBER_OF_ISTEPS) ||
+                (ISteps[row + 1].major > majorNum))
+            {
+                position = row;
+                break;
+            }
+        }
+    }
+
+    return position;
+}
+
+// ---------------------------------------------------------------------
+// Get the position (index) of the first minor number for a given major
+// ---------------------------------------------------------------------
+constexpr std::uint16_t getPosFirstMinorNumber(std::uint16_t majorNum)
+{
+    if (majorNum > EDBG_LAST_ISTEP_NUM)
+    {
+        return EDBG_INVALID_POSITION;
+    }
+
+    for (std::uint16_t row = 0; row < EDBG_NUMBER_OF_ISTEPS; ++row)
+    {
+        if (ISteps[row].major == majorNum)
+        {
+            return row;
+        }
+    }
+
+    return EDBG_INVALID_POSITION;
+}
+
+// ---------------------------------------------------------------------
+// Get the major and minor number for the given istep name
+// ---------------------------------------------------------------------
+constexpr bool getIStepNumber(const std::string& istepName, uint16_t& major,
+                              uint16_t& minor)
+{
+    using namespace istep_table;
+
+    major = EDBG_INVALID_ISTEP_NUM;
+    minor = EDBG_INVALID_ISTEP_NUM;
+
+    for (const auto& step : ISteps)
+    {
+        if (istepName == step.name)
+        {
+            major = step.major;
+            minor = step.minor;
+            return true;
+        }
+    }
+    return false;
+}
+// ---------------------------------------------------------------------
+// Get the position (index) of the istep name
+// ---------------------------------------------------------------------
+constexpr std::uint16_t getPosition(std::string_view istepName)
+{
+    for (std::uint16_t row = 0; row < EDBG_NUMBER_OF_ISTEPS; ++row)
+    {
+        if (ISteps[row].name == istepName)
+        {
+            return row;
+        }
+    }
+    return EDBG_INVALID_POSITION;
+}
+
+// ---------------------------------------------------------------------
+// Get the minor number for a given istep table position
+// ---------------------------------------------------------------------
+constexpr std::uint16_t getIStepMinorNumber(std::uint16_t position)
+{
+    if (position < EDBG_NUMBER_OF_ISTEPS)
+    {
+        return ISteps[position].minor;
+    }
+
+    return EDBG_INVALID_ISTEP_NUM;
+}
+} // namespace istep_table

--- a/ecmd-plugin/meson.build
+++ b/ecmd-plugin/meson.build
@@ -1,0 +1,78 @@
+# meson.build for ecmd-plugin
+
+# ---------------------------------------------------------------------
+# Source files
+# ---------------------------------------------------------------------
+
+ecmd_plugin_src = files(
+  'ecmd_dll_capi.cpp',
+  'ecmd_dll_istep.cpp',
+  'ecmd_dll_error.cpp',
+  'ecmd_dll_ring.cpp',
+  'ecmd_util.cpp',
+)
+
+# ---------------------------------------------------------------------
+# Include directories
+# ---------------------------------------------------------------------
+
+ecmd_plugin_inc = include_directories('.')
+
+# ---------------------------------------------------------------------
+# Libraries
+# ---------------------------------------------------------------------
+
+ipl_dep  = cxx.find_library('ipl', required: true)
+ecmd_dep = cxx.find_library('ecmd', required: true)
+pdbg_dep = cxx.find_library('pdbg', required: true)
+phosphor_logging_dep = dependency('phosphor-logging')
+
+ecmd_plugin_deps = [
+  ipl_dep,
+  ecmd_dep,
+  pdbg_dep,
+  phosphor_logging_dep,
+]
+
+# ---------------------------------------------------------------------
+# Build the shared library
+# ---------------------------------------------------------------------
+ecmd_plugin_lib = shared_library(
+  'ecmd-plugin',
+  ecmd_plugin_src,
+  include_directories: [
+      ecmd_plugin_inc,
+  ],
+  dependencies: ecmd_plugin_deps,
+  version: '1.0.0',
+  soversion: '1',
+  install: true,
+  install_dir: get_option('libdir'),
+)
+
+ecmd_plugin_dep = declare_dependency(
+    link_with: ecmd_plugin_lib,
+    include_directories: [ecmd_plugin_inc],
+    dependencies: ecmd_plugin_deps
+)
+
+# ---------------------------------------------------------------------
+# pkg-config file generation
+# ---------------------------------------------------------------------
+pkgconfig = import('pkgconfig')
+
+pkgconfig.generate(
+  libraries: ecmd_plugin_lib,        # <— use the variable returned above
+  version: meson.project_version(),
+  filebase: 'ecmd-plugin',
+  name: 'ecmd-plugin',
+  description: 'eCMD platform plugin shared library',
+  subdirs: 'ecmd',
+  requires: [
+    'ipl',
+    'pdbg',
+    'ecmd',
+    'phosphor-logging'
+  ],
+)
+

--- a/meson.build
+++ b/meson.build
@@ -301,3 +301,6 @@ if not get_option('tests').disabled()
         ),
     )
 endif
+if get_option('ecmd-plugin').enabled()
+  subdir('ecmd-plugin')
+endif

--- a/meson.options
+++ b/meson.options
@@ -2,6 +2,7 @@ option('tests', type: 'feature', description: 'Build tests.')
 option('p9', type: 'feature', description: 'Enable support for POWER9')
 option('openfsi', type: 'feature', description: 'Enable support for OpenFSI')
 option('phal', type: 'feature', description: 'Enable support for PHAL')
+option('ecmd-plugin', type: 'feature', description: 'Enable support for ecmd-plugin')
 
 option(
     'DEVTREE_EXPORT_FILTER_FILE',


### PR DESCRIPTION
This commit introduces the initial implementation required to run iSteps via the ECMD DLL plugin interface.

- Added implementation for:
    * dllIStepsByNumber

- Added default stub definitions for several optional plugin methods. These functions are intentionally left without full implementations and simply return ECMD_SUCCESS. They will be implemented later on a need basis.

This forms the baseline ECMD DLL plugin integration needed for iStep execution.

Tested
root@p11bmc:/tmp# istep -s0
<6> dllIStepsByNumber
<6> number of isteps bits set is 1
<6> executeIstep major=0 minorstart=1 minorend=16
<6> enter istepPowerOn
Reset: Success
<3> Requested istep poweron is noop
<3> Requested istep startipl is noop
<3> Requested istep disableattns is noop
<3> PASS: istep updatehwmodel
<3> Requested istep alignment_check is noop
<3> PASS: istep set_ref_clock
<3> PASS: istep proc_clock_test
<3> Requested istep proc_prep_ipl is noop
<3> Requested istep edramrepair is noop
<3> Requested istep asset_protection is noop
<3> PASS: istep proc_select_boot_prom
<3> Requested istep hb_config_update is noop
<3> PASS: istep sbe_config_update
<3> PASS: istep sbe_start
<3> Requested istep startprd is noop
<3> PASS: istep proc_attn_listen

Change-Id: I65fd37d4c7652950ab1aa18ff6bf8cdee3aafa6d