### PR TITLE
phal: Hardware procedure error handling support

### DIFF
--- a/procedures/phal/start_host.cpp
+++ b/procedures/phal/start_host.cpp
@@ -5,6 +5,7 @@
 #include "extensions/phal/phal_error.hpp"
 #include "util.hpp"
 
+#include <errl_factory.H>
 #include <libekb.H>
 #include <targeting/predicates/predicateattrval.H>
 #include <targeting/predicates/predicatepostfixexpr.H>
@@ -16,6 +17,7 @@
 #include <ext_interface.hpp>
 #include <nlohmann/json.hpp>
 #include <phosphor-logging/log.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <registration.hpp>
 
 #include <format>
@@ -268,7 +270,7 @@ void startHost(enum ipl_type iplType = IPL_TYPE_NORMAL)
 {
     try
     {
-        //TODO p12-refactor need to use env variable here for dtb
+        // TODO p12-refactor need to use env variable here for dtb
         TargetService::instance().init("/tmp/targeting_test.dtb");
 
         ipl_set_type(iplType);
@@ -307,6 +309,19 @@ void startHost(enum ipl_type iplType = IPL_TYPE_NORMAL)
     if (rc > 0)
     {
         log<level::ERR>("step 0 failed to start the host");
+        auto errlHandle = errl::factory::createSbeHWPFailure();
+        if (errlHandle && *errlHandle)
+        {
+            const auto& entries = (*errlHandle)->getEntries();
+            for (const auto& entryPtr : entries)
+            {
+                if (entryPtr)
+                {
+		    lg2::error("invoking createPstSbeErrorPEL");
+                    openpower::pel::createPstSbeErrorPEL(entryPtr.get());
+                }
+            }
+        }
         throw std::runtime_error("Failed to execute host start boot step");
     }
 }


### PR DESCRIPTION
Test result:

root@xxx:~# peltool -i 0x50000842
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc host processor control",
    "Created at":               "12/02/2025 06:38:08",
    "Committed at":             "12/02/2025 06:38:08",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50000842",
    "Entry Id":                 "0x50000842",
    "BMC Event Log Id":         "753"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Unrecoverable Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},s
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc host processor control",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "Failure occurred during boot process"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD503001",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9105-22B",
    "Reporting Serial Number":  "139F210",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1210.00-1.21",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD503001_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9105-22B",
    "Serial Number":            "139F210"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "1.54 1.16 1.15",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 1h 44m 17s",
    "BootState": "Unspecified",
    "ChassisState": "TransitioningToOn",
    "FW Version ID": "fw1210.00-1.21-3-g1df0c30c21-dirty",
    "HostState": "TransitioningToRunning",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "HWP_CDG_TGT_01_CO_PRIORITY": "MEDIUM",
    "HWP_CDG_TGT_01_CO_REQ": "true",
    "HWP_CDG_TGT_01_DECONF_REQ": "true",
    "HWP_CDG_TGT_01_GUARD_REQ": "true",
    "HWP_CDG_TGT_01_GUARD_TYPE": "GARD_Fatal",
    "HWP_FFDC_AVS_BUS": "01",
    "HWP_FFDC_AVS_RAIL": "00",
    "HWP_FFDC_CBS_ENVSTAT_READ": "3c000020",
    "HWP_HW_CO_01_CALLOUT_PLANAR": "false",
    "HWP_HW_CO_01_CLK_POS": "255",
    "HWP_HW_CO_01_HW_ID": "UN_SUPPORTED_PART",
    "HWP_HW_CO_01_PRIORITY": "HIGH",
    "HWP_RC": "RC_VDN_PGOOD_NOT_SET",
    "HWP_RC_DESC": "Nest power (VDN) Power Good indication not set"
},
"User Data 2": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "Data": [
        {
            "Deconfigured": true,
            "EntityPath": [
                35,
                1,
                0,
                2,
                0,
                5,
                0
            ],
            "GuardType": "GARD_Fatal",
            "Guarded": true,
            "Priority": "M"
        }
    ]
},
"User Data 3": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "PEL Internal Debug Data": {
        "SRC": [
            "Failed extracting callout data from JSON: JSON callout needs either an inventory path or location code"
        ]
    }
}
}

Change-Id: I03b9303f562552d3d0ef587748090795e2be9f92