### PR TITLE
remove installs on templated services and targets

### DIFF
--- a/service_files/phal-import-devtree@.service.in
+++ b/service_files/phal-import-devtree@.service.in
@@ -12,4 +12,4 @@ Type=oneshot
 ExecStart=/usr/bin/openpower-proc-control importDevtree
 
 [Install]
-WantedBy=multi-user.target
+# Handled by bitbake recipe


### PR DESCRIPTION
New yocto is getting more stringent on installation of templated service and targets.

Templated services are installed by bitbake recipes so there's no need to have the WantedBy/RequiredBy in those services.

Here's a summary of the error we get for packages which have templated services doing an install:
```
ERROR: obmc-phosphor-image-1.0-r0 do_rootfs: Postinstall scriptlets of
['<package>' 'inst returned 1, marking as unpacked only, configuration
required on target']
If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget:${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
```

Tested:
- Confirmed image builds with new yocto and services are still installed as expected

Change-Id: Idefed9dec8c295a2c8abc486c4a6a82097c61adc